### PR TITLE
Add steam service

### DIFF
--- a/modules/controller.nix
+++ b/modules/controller.nix
@@ -1,0 +1,42 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+in
+{
+  options = {
+    jovian = {
+      enableControllerUdevRules = mkOption {
+        type = types.bool;
+        default = true;
+        description = ''
+            Enables udev rules to make the controller controllable by users.
+
+            Without this, neither steam, nor any other userspace client can
+            switch the controller from out of its default "lizard" mode.
+        '';
+      };
+    };
+  };
+  config = mkMerge [
+    (mkIf config.jovian.enableControllerUdevRules {
+      # Necessary for the controller parts to work correctly.
+      services.udev.extraRules = ''
+        # This rule is necessary for gamepad emulation.
+        KERNEL=="uinput", MODE="0660", GROUP="users", OPTIONS+="static_node=uinput"
+
+        # This rule is needed for basic functionality of the controller in Steam and keyboard/mouse emulation
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666"
+
+        # Valve HID devices over USB hidraw
+        KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0666"
+      '';
+    })
+  ];
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./controller.nix
     ./graphical.nix
     ./hw-support.nix
     ./kernel.nix

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,6 +5,7 @@
     ./kernel.nix
     ./overlay.nix
     ./sound.nix
+    ./steam.nix
     ./workarounds.nix
   ];
 }

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -8,6 +8,8 @@ let
     mkOption
     types
   ;
+  # ¯\_(ツ)_/¯
+  token = "steampal_stable_9a24a2bf68596b860cb6710d9ea307a76c29a04d";
 in
 {
   options = {
@@ -44,6 +46,9 @@ in
               gamescope
               steam
             ])}"
+            # This forces the user in the steampal beta.
+            # Not ideal, as it's not reversed by disabling this service.
+            echo "${token}" > ~/.local/share/Steam/package/beta
             exec gamescope \
               --fullscreen \
               --steam \

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -34,6 +34,7 @@ in
     (mkIf config.jovian.steam.enable {
       hardware.opengl.driSupport32Bit = true;
       hardware.pulseaudio.support32Bit = true;
+      jovian.enableControllerUdevRules = true;
 
       systemd.user.services."steam" = {
         enable = true;

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -1,0 +1,64 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+in
+{
+  options = {
+    jovian = {
+      steam = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Enables stopped-by-default systemd service to launch steam
+            in "PAL" user interface (steam deck interface).
+
+            Use `systemctl --user start steam` to launch.
+
+            Use `systemctl --user stop steam` to stop.
+          '';
+        };
+      };
+    };
+  };
+  config = mkMerge [
+    (mkIf config.jovian.steam.enable {
+      hardware.opengl.driSupport32Bit = true;
+      hardware.pulseaudio.support32Bit = true;
+
+      systemd.user.services."steam" = {
+        enable = true;
+        serviceConfig = {
+          KillMode = "process";
+          Restart = "always";
+          RestartSec = "1";
+          ExecStart = pkgs.writeShellScript "steam-pal-ui" ''
+            export PATH="$PATH:${lib.makeBinPath (with pkgs;[
+              gamescope
+              steam
+            ])}"
+            exec gamescope \
+              --fullscreen \
+              --steam \
+              -- steam -gamepadui -pipewire-dmabuf
+          '';
+        };
+        unitConfig = {
+          ConditionPathExists = "/run/user/%U";
+        };
+        # wantedBy is not used, as this would make it a hard
+        # requirement on the graphical session.
+        # This service is only used to manage (start/stop) steam.
+        requisite = [ "graphical-session.target" ];
+        partOf = [ "graphical-session.target" ];
+      };
+    })
+  ];
+}

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -53,7 +53,7 @@ in
             exec gamescope \
               --fullscreen \
               --steam \
-              -- steam -gamepadui -pipewire-dmabuf
+              -- steam -steamos3 -gamepadui -pipewire-dmabuf
           '';
         };
         unitConfig = {

--- a/overlay.nix
+++ b/overlay.nix
@@ -19,4 +19,7 @@ in
       kernelPatches.export-rt-sched-migrate
     ];
   };
+  gamescope = super.callPackage ./pkgs/gamescope {
+    udev = final.systemdMinimal;
+  };
 }

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -1,0 +1,97 @@
+{ stdenv
+, fetchFromGitHub
+
+, meson
+, pkg-config
+, cmake
+, ninja
+
+, xorg
+, libdrm
+, vulkan-loader
+, wayland
+, wayland-protocols
+, libxkbcommon
+, libcap
+, SDL2
+, pipewire
+, mesa
+, udev
+, pixman
+, libinput
+, libseat
+, xwayland
+, glslang
+
+, stb
+, wlroots
+, libliftoff
+}:
+
+let
+in
+stdenv.mkDerivation {
+  pname = "gamescope";
+  version = "3.11.28-beta4";
+  src = fetchFromGitHub {
+    owner = "Plagman";
+    repo = "gamescope";
+    rev = "refs/tags/3.11.28-beta4";
+    hash = "sha256-3L3bQIPPfScvtN1dduh10dQu/AuTmD4dHNp3JjBIBLA=";
+  };
+
+  buildInputs = [
+    xorg.libX11
+    xorg.libXdamage
+    xorg.libXcomposite
+    xorg.libXrender
+    xorg.libXext
+    xorg.libXxf86vm
+    xorg.libXtst
+    xorg.libXres
+    libdrm
+    vulkan-loader
+    wayland
+    wayland-protocols
+    libxkbcommon
+    libcap
+    SDL2
+    pipewire
+    mesa
+    udev
+    pixman
+    libinput
+    libseat
+    xwayland
+    xorg.xcbutilwm
+    xorg.xcbutilerrors
+    glslang
+    xorg.libXi
+  ];
+
+  prePatch = ''
+    echo ":: Copying stb"
+    cp -vr "${stb.src}" subprojects/stb
+    chmod -R +w subprojects/stb
+    cp "subprojects/packagefiles/stb/meson.build" "subprojects/stb/"
+
+    echo ":: Copying wlroots"
+    rmdir subprojects/wlroots
+    cp -vr "${wlroots.src}" subprojects/wlroots
+    chmod -R +w subprojects/wlroots
+
+    echo ":: Copying libliftoff"
+    rmdir subprojects/libliftoff
+    cp -vr "${libliftoff.src}" subprojects/libliftoff
+    chmod -R +w subprojects/libliftoff
+  '';
+
+  nativeBuildInputs = [
+    cmake
+    meson
+    pkg-config
+    ninja
+  ];
+
+  dontUseCmakeConfigure = true;
+}


### PR DESCRIPTION
This adds a systemd user service to manage steam in its "pal" mode.

Usage:

```
 $ systemctl --user start steam
```

~~Note that "switch to desktop" doesn't work. This will need to be investigated, to see if there's a way to force this to work. The idea would be to stop the steam "pal" service when this is used.~~

~~See: https://github.com/Jovian-Experiments/Jovian-NixOS/issues/4~~

### TODO

 - [x] Add gamescope expression.
 - [x] Add handling of opting-in into PAL beta in a before script.

### Future TODO?

 - [ ] Add gamescope configuration options (#5)