### PR TITLE
Add Jovian-Controller user service

### DIFF
--- a/modules/controller.nix
+++ b/modules/controller.nix
@@ -61,6 +61,14 @@ in
         wantedBy = [ "graphical-session.target" ];
         partOf = [ "graphical-session.target" ];
       };
+      # Configures the steam service to conflict and restart the
+      # Jovian-Controller service.
+      systemd.user.services."steam" = mkIf config.jovian.steam.enable {
+        conflicts = [ "Jovian-Controller.service" ];
+        serviceConfig = {
+          ExecStopPost = "systemctl --user start Jovian-Controller.service";
+        };
+      };
     })
   ];
 }

--- a/overlay.nix
+++ b/overlay.nix
@@ -22,6 +22,6 @@ in
   gamescope = super.callPackage ./pkgs/gamescope {
     udev = final.systemdMinimal;
   };
-
+  jovian-controller = super.callPackage ./pkgs/jovian-controller { };
   jupiter-fan-control = final.callPackage ./pkgs/jupiter-fan-control { };
 }

--- a/pkgs/jovian-controller/Gemfile
+++ b/pkgs/jovian-controller/Gemfile
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+gem "hexdump"
+gem "libusb"
+gem "uinput-device"

--- a/pkgs/jovian-controller/Gemfile.lock
+++ b/pkgs/jovian-controller/Gemfile.lock
@@ -1,0 +1,26 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ffi (1.15.5)
+    hexdump (1.0.0)
+    libusb (0.6.4)
+      ffi (~> 1.0)
+      mini_portile2 (~> 2.1)
+    linux_input (1.1.1)
+      ffi (~> 1.9)
+    mini_portile2 (2.8.0)
+    uinput (1.2.0)
+      linux_input (~> 1.0)
+    uinput-device (0.4.0)
+      uinput (~> 1.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  hexdump
+  libusb
+  uinput-device
+
+BUNDLED WITH
+   2.2.32

--- a/pkgs/jovian-controller/default.nix
+++ b/pkgs/jovian-controller/default.nix
@@ -1,0 +1,42 @@
+{ stdenv
+, fetchFromGitHub
+, bundlerEnv
+, ruby
+}:
+let
+  gems = bundlerEnv {
+    name = "Jovian-Controller-env";
+    inherit ruby;
+    gemdir  = ./.;
+  };
+in stdenv.mkDerivation {
+  pname = "Jovian-Controller";
+  version = "unstable-2022-04-15";
+
+  src = fetchFromGitHub {
+    owner = "Jovian-Experiments";
+    repo = "Jovian-Controller";
+    rev = "669276f8e6be0ec1277a0c88c561357c65dbdfe0";
+    sha256 = "sha256-vHsq7lQFjjUsSOa+Sbd2AVrLvEj70dcInC44eCYYtXY=";
+  };
+
+  buildInputs = [
+    gems
+    gems.wrappedRuby
+  ];
+
+  installPhase = ''
+    mkdir -p $out/libexec
+    cp  -rvt $out/libexec \
+      *.rb \
+      lib
+
+    # Add a ruby-based wrapper that launches the script with the right ruby.
+    mkdir -p $out/bin
+    cat <<EOF > $out/bin/Jovian-Controller
+    #!${gems.wrappedRuby}/bin/ruby
+    load(File.join(__dir__(), "..", "libexec", "jovian-controller.rb"))
+    EOF
+    chmod +x $out/bin/Jovian-Controller
+  '';
+}

--- a/pkgs/jovian-controller/gemset.nix
+++ b/pkgs/jovian-controller/gemset.nix
@@ -1,0 +1,76 @@
+{
+  ffi = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1862ydmclzy1a0cjbvm8dz7847d9rch495ib0zb64y84d3xd4bkg";
+      type = "gem";
+    };
+    version = "1.15.5";
+  };
+  hexdump = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1787w456yzmy4c13ray228n89a5wz6p6k3ibssjvy955qlr44b7g";
+      type = "gem";
+    };
+    version = "1.0.0";
+  };
+  libusb = {
+    dependencies = ["ffi" "mini_portile2"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "005q4f3bi68yapza1vxamgwz2gpix2akci52s4yvr03hsxi137a6";
+      type = "gem";
+    };
+    version = "0.6.4";
+  };
+  linux_input = {
+    dependencies = ["ffi"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1cwbq590hgmpfpwjsjq8cqbqd1j0ygs3ib6ncycsg622xr3fgy85";
+      type = "gem";
+    };
+    version = "1.1.1";
+  };
+  mini_portile2 = {
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rapl1sfmfi3bfr68da4ca16yhc0pp93vjwkj7y3rdqrzy3b41hy";
+      type = "gem";
+    };
+    version = "2.8.0";
+  };
+  uinput = {
+    dependencies = ["linux_input"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16503hskym9z0yk2wlk055kikfnm3hvmshidx2g5c5jy6nvh931m";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  uinput-device = {
+    dependencies = ["uinput"];
+    groups = ["default"];
+    platforms = [];
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "18k205fjhd16qwd0wcrkig2z0g39bsxh3k4rhyjrvkm1c1cb42kk";
+      type = "gem";
+    };
+    version = "0.4.0";
+  };
+}


### PR DESCRIPTION
Self-explanatory.

The service config will be brought up automatically, and conflicts with the steam service.

This way, the expectation is that (in a future step?) a user interface can launch steam by "just asking nicely" to the service, and the userspace input driver will be stopped as needed.

~~Builds on top of #7.~~