### PR TITLE
modules: Add fan-control

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,6 +1,7 @@
 {
   imports = [
     ./controller.nix
+    ./fan-control.nix
     ./graphical.nix
     ./hw-support.nix
     ./kernel.nix

--- a/modules/fan-control.nix
+++ b/modules/fan-control.nix
@@ -1,0 +1,48 @@
+{ pkgs, config, lib, ... }:
+
+# Userspace fan control
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.jovian;
+in
+{
+  options = {
+    jovian = {
+      enableOsFanControl = mkOption {
+        description = ''
+          Whether to enable the OS-controlled fan curve.
+
+          This is enabled by default since SteamOS 3.2.
+        '';
+        type = types.bool;
+        default = true;
+      };
+    };
+  };
+
+  config = mkIf (cfg.enableOsFanControl) {
+    systemd.services.jupiter-fan-control = {
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.dmidecode ];
+      serviceConfig = {
+        ExecStart = "${pkgs.jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --run";
+        ExecStopPost = "${pkgs.jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --stop";
+        OOMScoreAdjust = -1000;
+        Restart = "on-failure";
+
+        # disable debug journal logging
+        StandardOutput = "null";
+      };
+      environment = {
+        PYTHONUNBUFFERED = "1";
+      };
+    };
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -22,4 +22,6 @@ in
   gamescope = super.callPackage ./pkgs/gamescope {
     udev = final.systemdMinimal;
   };
+
+  jupiter-fan-control = final.callPackage ./pkgs/jupiter-fan-control { };
 }

--- a/pkgs/jupiter-fan-control/default.nix
+++ b/pkgs/jupiter-fan-control/default.nix
@@ -1,0 +1,41 @@
+{ lib, stdenv, python3, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  pname = "jupiter-fan-control";
+  version = "20220705.1";
+
+  # TODO: Replace with https://gitlab.steamos.cloud/jupiter/jupiter-fan-control
+  # once it becomes public
+  src = fetchFromGitHub {
+    owner = "Jovian-Experiments";
+    repo = "jupiter-fan-control";
+    rev = version;
+    sha256 = "sha256-Ij4yflupmlatbMFhGLUNv0bHo9H4tRlk2IX6pwnRFMk=";
+  };
+
+  buildInputs = [
+    (python3.withPackages (py: with py; [
+      pyyaml
+    ]))
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/share
+    cp -r usr/share/jupiter-fan-control $out/share
+    sed -i "s|/usr/share/|$out/share/|g" $out/share/jupiter-fan-control/fancontrol.py
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Steam Deck (Jupiter) userspace fan controller";
+
+    # PKGBUILD says MIT, but PID.py is licensed under GPLv3+
+    license = licenses.gpl3Plus;
+  };
+}


### PR DESCRIPTION
SteamOS 3.2 [introduced](https://store.steampowered.com/news/app/1675200/view/3297210455204349335) a new OS-controlled fan curve that's enabled by default. It makes the fan much quieter during low loads.