### PR TITLE
sound: Fix internal speakers

### DIFF
--- a/modules/sound.nix
+++ b/modules/sound.nix
@@ -10,18 +10,49 @@
     };
   };
 
-  config = lib.mkIf config.jovian.enableSoundSupport {
-    environment.variables.ALSA_CONFIG_UCM2 = "/run/current-system/sw/share/alsa/ucm2";
-    systemd.user.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
-    systemd.services.pulseaudio.environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+  config = lib.mkIf config.jovian.enableSoundSupport (lib.mkMerge [
+    {
+      hardware.pulseaudio.enable = lib.mkDefault false;
 
-    environment.pathsToLink = [
-      "share/alsa/ucm2/conf.d"
-    ];
+      services.pipewire = {
+        enable = lib.mkDefault true;
+        pulse.enable = lib.mkDefault true;
+        alsa.enable = lib.mkDefault true;
+      };
 
-    environment.systemPackages = with pkgs; [
-      alsa-lib # So it gets linked into `pathsToLink`
-      acp5x-ucm
-    ];
-  };
+      # TODO: overlay on top of the vanilla alsa-lib using environment.pathsToLink
+      # Currently this does not work due to some weird path concatenation behavior in alsa-lib:
+      #
+      #     openat(AT_FDCWD, "/run/current-system/sw/share/alsa/ucm2/conf.d/acp5x//nix/store/hxm24krvwjyys9zfirn203sf3ncm44gs-acp5x-ucm-jupiter-20220310.1000/share/alsa/ucm2/conf.d/acp5x/HiFi.conf", O_RDONLY) = -1 ENOENT (No such file or directory)
+      environment.variables.ALSA_CONFIG_UCM2 = "${pkgs.acp5x-ucm}/share/alsa/ucm2";
+    }
+
+    # Pulseaudio
+    (lib.mkIf (config.hardware.pulseaudio.enable) (let
+      systemWide = config.hardware.pulseaudio.systemWide;
+    in {
+      systemd.services.pulseaudio = lib.mkIf systemWide {
+        environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+      };
+      systemd.user.services.pulseaudio = lib.mkIf (!systemWide) {
+        environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+      };
+    }))
+
+    # Pipewire
+    (lib.mkIf (config.services.pipewire.enable) (let
+      systemWide = config.services.pipewire.systemWide;
+      sessionManager =
+        if config.services.pipewire.wireplumber.enable then "wireplumber"
+        else if config.services.pipewire.media-session.enable then "pipewire-media-session"
+        else throw "Either wireplumber or pipewire-media-session must be enabled"; # unreachable
+    in {
+      systemd.services.${sessionManager} = lib.mkIf systemWide {
+        environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+      };
+      systemd.user.services.${sessionManager} = lib.mkIf (!systemWide) {
+        environment.ALSA_CONFIG_UCM2 = config.environment.variables.ALSA_CONFIG_UCM2;
+      };
+    }))
+  ]);
 }

--- a/pkgs/acp5x-ucm/default.nix
+++ b/pkgs/acp5x-ucm/default.nix
@@ -14,6 +14,12 @@ runCommandNoCC "acp5x-ucm-${version}" {
   mkdir -pv $out/share/alsa/ucm2/conf.d/acp5x
   cp -rv ${./acp5x}/* $out/share/alsa/ucm2/conf.d/acp5x/
 
+  # Temporary workaround for https://github.com/alsa-project/alsa-lib/pull/249
+  # Fixed in alsa-lib 1.2.7.2
+  mv $out/share/alsa/ucm2/conf.d/acp5x/acp5x.conf{,.real}
+  # not using the absolute path as the target is intentional - it's otherwise broken :/
+  ln -s acp5x.conf.real $out/share/alsa/ucm2/conf.d/acp5x/acp5x.conf
+
   # This *overrides the alsa-lib ucm.conf* if also linked in `pathsToLink`.
   cat > $out/share/alsa/ucm2/ucm.conf <<EOF
   Syntax 3


### PR DESCRIPTION
Working around [an upstream bug](https://github.com/alsa-project/alsa-lib/pull/249) so our additional UCM files work.

<details>
<summary>Outdated stuff</summary>

<del>
With Pipewire, the UCM files are not necessary and don't seem to help when added to the services with the `ALSA_CONFIG_UCM2` variable.

I can't seem to get them to work with pulseaudio even with the UCM files, but it makes sense to move to Pipewire as it's what SteamOS is using.

Before testing, delete `/var/lib/alsa/asound.state` and reboot.
</del>
</details>