### PR TITLE
Move Steam Deck-specific configurations under jovian.devices.steamdeck

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,12 +1,7 @@
 {
   imports = [
-    ./controller.nix
-    ./fan-control.nix
-    ./graphical.nix
-    ./hw-support.nix
-    ./kernel.nix
+    ./steamdeck
     ./overlay.nix
-    ./sound.nix
     ./steam.nix
     ./workarounds.nix
   ];

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -45,17 +45,6 @@ in
             Use `systemctl --user stop steam.target` to stop.
           '';
         };
-        enableUdevRules = mkOption {
-          type = types.bool;
-          default = true;
-          description = ''
-            Whether to make certain device attributes controllable by users.
-
-            The Steam Deck Client directly modifies several device attributes to
-            control the display brightness and to enable performance tuning (TDP
-            limit, GPU clock control).
-          '';
-        };
       };
     };
   };
@@ -63,7 +52,6 @@ in
     (mkIf config.jovian.steam.enable {
       hardware.opengl.driSupport32Bit = true;
       hardware.pulseaudio.support32Bit = true;
-      jovian.enableControllerUdevRules = true;
 
       systemd.user.services."steam" = {
         enable = true;
@@ -108,22 +96,6 @@ in
         requisite = [ "graphical-session.target" ];
         partOf = [ "graphical-session.target" ];
       };
-    })
-    (mkIf (config.jovian.steam.enableUdevRules) {
-      services.udev.extraRules = ''
-        # Enables brightness slider in Steam
-        # - /sys/class/backlight/amdgpu_bl0/brightness
-        ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="amdgpu_bl0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
-
-        # Enables manual GPU clock control in Steam
-        # - /sys/class/drm/card0/device/power_dpm_force_performance_level
-        # - /sys/class/drm/card0/device/pp_od_clk_voltage
-        ACTION=="add", SUBSYSTEM=="pci", DRIVER=="amdgpu", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/%p/power_dpm_force_performance_level /sys/%p/pp_od_clk_voltage"
-
-        # Enables manual TDP limiter in Steam
-        # - /sys/class/hwmon/hwmon0/power{1,2}_cap
-        ACTION=="add", SUBSYSTEM=="hwmon", DEVPATH=="*/hwmon0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/%p/power1_cap /sys/%p/power2_cap"
-      '';
     })
   ];
 }

--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -8,13 +8,14 @@ let
     mkOption
     types
   ;
+  cfg = config.jovian.devices.steamdeck;
 in
 {
   options = {
-    jovian = {
+    jovian.devices.steamdeck = {
       enableControllerUdevRules = mkOption {
         type = types.bool;
-        default = true;
+        default = cfg.enable;
         description = ''
             Enables udev rules to make the controller controllable by users.
 
@@ -25,7 +26,7 @@ in
     };
   };
   config = mkMerge [
-    (mkIf config.jovian.enableControllerUdevRules {
+    (mkIf (cfg.enableControllerUdevRules) {
       # Necessary for the controller parts to work correctly.
       services.udev.extraRules = ''
         # This rule is necessary for gamepad emulation.

--- a/modules/steamdeck/default.nix
+++ b/modules/steamdeck/default.nix
@@ -1,0 +1,35 @@
+# Steam Deck-specific configurations
+#
+# jovian.devices.steamdeck
+
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkOption
+    types
+  ;
+in
+{
+  imports = [
+    ./controller.nix
+    ./fan-control.nix
+    ./graphical.nix
+    ./hw-support.nix
+    ./kernel.nix
+    ./perf-control.nix
+    ./sound.nix
+  ];
+
+  options = {
+    jovian.devices.steamdeck = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable Steam Deck-specific configurations.
+        '';
+      };
+    };
+  };
+}

--- a/modules/steamdeck/fan-control.nix
+++ b/modules/steamdeck/fan-control.nix
@@ -10,11 +10,11 @@ let
     mkOption
     types
   ;
-  cfg = config.jovian;
+  cfg = config.jovian.devices.steamdeck;
 in
 {
   options = {
-    jovian = {
+    jovian.devices.steamdeck = {
       enableOsFanControl = mkOption {
         description = ''
           Whether to enable the OS-controlled fan curve.
@@ -22,7 +22,7 @@ in
           This is enabled by default since SteamOS 3.2.
         '';
         type = types.bool;
-        default = true;
+        default = cfg.enable;
       };
     };
   };

--- a/modules/steamdeck/graphical.nix
+++ b/modules/steamdeck/graphical.nix
@@ -5,27 +5,27 @@ let
     mkIf
     mkMerge
   ;
-  cfg = config.jovian;
+  cfg = config.jovian.devices.steamdeck;
 in
 {
   options = {
-    jovian = {
+    jovian.devices.steamdeck = {
       enableEarlyModesetting = lib.mkOption {
-        default = true;
+        default = cfg.enable;
         type = lib.types.bool;
       };
       enableDRMRotationParam = lib.mkOption {
-        default = !config.jovian.hasKernelPatches;
+        default = !cfg.hasKernelPatches;
         type = lib.types.bool;
       };
       enableXorgRotation = lib.mkOption {
-        default = true;
+        default = cfg.enable;
         type = lib.types.bool;
       };
     };
   };
 
-  config = lib.mkMerge [
+  config = mkMerge [
     (mkIf cfg.enableEarlyModesetting {
       boot.initrd.kernelModules = [
         "amdgpu"

--- a/modules/steamdeck/hw-support.nix
+++ b/modules/steamdeck/hw-support.nix
@@ -10,21 +10,21 @@ let
     mkOption
     types
   ;
-  cfg = config.jovian;
+  cfg = config.jovian.devices.steamdeck;
 in
 {
   options = {
-    jovian = {
+    jovian.devices.steamdeck = {
       enableDefaultSysctlConfig = mkOption {
-        default = true;
+        default = cfg.enable;
         type = types.bool;
       };
       enableDefaultCmdlineConfig = mkOption {
-        default = true;
+        default = cfg.enable;
         type = types.bool;
       };
       enableDefaultStage1Modules = mkOption {
-        default = true;
+        default = cfg.enable;
         type = types.bool;
       };
     };

--- a/modules/steamdeck/perf-control.nix
+++ b/modules/steamdeck/perf-control.nix
@@ -1,0 +1,45 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.jovian.devices.steamdeck;
+in
+{
+  options = {
+    jovian.devices.steamdeck = {
+      enablePerfControlUdevRules = mkOption {
+        type = types.bool;
+        default = cfg.enable;
+        description = ''
+          Whether to make performance-related device attributes controllable by users.
+
+          The Steam Deck Client directly modifies several device attributes to
+          control the display brightness and to enable performance tuning (TDP
+          limit, GPU clock control).
+        '';
+      };
+    };
+  };
+  config = mkIf (cfg.enablePerfControlUdevRules) {
+    services.udev.extraRules = ''
+      # Enables brightness slider in Steam
+      # - /sys/class/backlight/amdgpu_bl0/brightness
+      ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="amdgpu_bl0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
+
+      # Enables manual GPU clock control in Steam
+      # - /sys/class/drm/card0/device/power_dpm_force_performance_level
+      # - /sys/class/drm/card0/device/pp_od_clk_voltage
+      ACTION=="add", SUBSYSTEM=="pci", DRIVER=="amdgpu", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/%p/power_dpm_force_performance_level /sys/%p/pp_od_clk_voltage"
+
+      # Enables manual TDP limiter in Steam
+      # - /sys/class/hwmon/hwmon0/power{1,2}_cap
+      ACTION=="add", SUBSYSTEM=="hwmon", DEVPATH=="*/hwmon0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/%p/power1_cap /sys/%p/power2_cap"
+    '';
+  };
+}

--- a/modules/steamdeck/sound.nix
+++ b/modules/steamdeck/sound.nix
@@ -1,16 +1,19 @@
 { config, lib, pkgs, ... }:
 
+let
+  cfg = config.jovian.devices.steamdeck;
+in
 {
   options = {
-    jovian = {
+    jovian.devices.steamdeck = {
       enableSoundSupport = lib.mkOption {
-        default = true;
+        default = cfg.enable;
         type = lib.types.bool;
       };
     };
   };
 
-  config = lib.mkIf config.jovian.enableSoundSupport (lib.mkMerge [
+  config = lib.mkIf (cfg.enableSoundSupport) (lib.mkMerge [
     {
       hardware.pulseaudio.enable = lib.mkDefault false;
 

--- a/modules/workarounds.nix
+++ b/modules/workarounds.nix
@@ -1,5 +1,7 @@
 { config, lib, pkgs, ... }:
-
+let
+  cfg = config.jovian.workarounds;
+in
 {
   options = {
     jovian = {
@@ -13,7 +15,7 @@
   };
 
   config = {
-    nixpkgs.overlays = lib.mkIf (config.jovian.workarounds.ignoreMissingKernelModules) [
+    nixpkgs.overlays = lib.mkIf (cfg.ignoreMissingKernelModules) [
       (final: super: {
         # Workaround for modules expected by NixOS not being built
         # (vmw_balloon, among most likely other)


### PR DESCRIPTION
This makes it easier for non-Steam Deck users to obtain a Deck-like experience without the hardware-specific bits (https://github.com/Jovian-Experiments/Jovian-NixOS/pull/13#discussion_r929420215).

This is a breaking change. The Steam Deck-specific bits are no longer enabled unless you set `jovian.devices.steamdeck.enable = true`.