### PR TITLE
steamdeck-firmware: init

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -24,6 +24,7 @@ in
 
   jupiter-hw-support = final.callPackage ./pkgs/jupiter-hw-support { };
   steamdeck-hw-theme = final.callPackage ./pkgs/jupiter-hw-support/theme.nix { };
+  steamdeck-firmware = final.callPackage ./pkgs/jupiter-hw-support/firmware.nix { };
 
   steam-session = super.callPackage ./pkgs/steam-session { };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -25,6 +25,7 @@ in
   jupiter-hw-support = final.callPackage ./pkgs/jupiter-hw-support { };
   steamdeck-hw-theme = final.callPackage ./pkgs/jupiter-hw-support/theme.nix { };
   steamdeck-firmware = final.callPackage ./pkgs/jupiter-hw-support/firmware.nix { };
+  steamdeck-bios-fwupd = final.callPackage ./pkgs/jupiter-hw-support/bios-fwupd.nix { };
 
   steam-session = super.callPackage ./pkgs/steam-session { };
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -26,6 +26,7 @@ in
   steamdeck-hw-theme = final.callPackage ./pkgs/jupiter-hw-support/theme.nix { };
   steamdeck-firmware = final.callPackage ./pkgs/jupiter-hw-support/firmware.nix { };
   steamdeck-bios-fwupd = final.callPackage ./pkgs/jupiter-hw-support/bios-fwupd.nix { };
+  jupiter-dock-updater-bin = final.callPackage ./pkgs/jupiter-dock-updater-bin { };
 
   steam-session = super.callPackage ./pkgs/steam-session { };
 

--- a/pkgs/jupiter-dock-updater-bin/default.nix
+++ b/pkgs/jupiter-dock-updater-bin/default.nix
@@ -1,0 +1,41 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, autoPatchelfHook
+, makeWrapper
+, libusb
+}:
+
+stdenv.mkDerivation rec {
+  pname = "jupiter-dock-updater-bin";
+  version = "20220921.01";
+
+  src = fetchFromGitHub {
+    owner = "Jovian-Experiments";
+    repo = "jupiter-dock-updater-bin";
+    rev = "jupiter-${version}";
+    hash = "sha256-rlHUHIaRBHK5KlCklPh0X0Is6D2sVhB6h6yMZZDRPUk=";
+  };
+
+  buildInputs = [
+    libusb
+  ];
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r packaged/usr/lib $out/
+    makeWrapper $out/lib/jupiter-dock-updater/jupiter-dock-updater.sh $out/bin/jupiter-dock-updater
+
+    runHook postInstall
+  '';
+}

--- a/pkgs/jupiter-hw-support/SteamDeckBIOS.metainfo.xml
+++ b/pkgs/jupiter-hw-support/SteamDeckBIOS.metainfo.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="firmware">
+  <id>value.Jupiter.BIOS.firmware</id>
+  <name>Steam Deck</name>
+  <provides>
+    <firmware type="flashed">bbb1cf06-f7b9-4466-adcc-6b8815bd99e6</firmware>
+  </provides>
+  <custom>
+    <value key="LVFS::UpdateProtocol">org.uefi.capsule</value>
+  </custom>
+  <releases>
+    <release version="@versionNumber@" date="@releaseDate@" urgency="high">
+      <checksum type="sha1" filename="@filename@" target="content">@sha1@</checksum>
+      <checksum type="sha256" filename="@filename@" target="content">@sha256@</checksum>
+      <artifacts>
+        <artifact type="binary">
+          <filename>@filename@</filename>
+          <checksum type="sha1">@sha1@</checksum>
+          <checksum type="sha256">@sha256@</checksum>
+        </artifact>
+      </artifacts>
+    </release>
+  </releases>
+</component>

--- a/pkgs/jupiter-hw-support/bios-fwupd.nix
+++ b/pkgs/jupiter-hw-support/bios-fwupd.nix
@@ -1,0 +1,71 @@
+# To install the BIOS update:
+#
+# 1. Disable Secure Boot, or have a `fwupd-efi` with `fwupdx64.efi.signed`.
+# 2. Set `OnlyTrusted=false` in `/etc/fwupd/daemon.conf`.
+#    (WARNING: This may make your device less secure!)
+# 3. Run `sudo fwupdmgr install /path/to/bios.cab`
+
+{ lib
+, runCommand
+, callPackage
+, jupiter-hw-support
+, gcab
+
+# The following parameters are for your enjoyment of flashing custom/older BIOSes:
+
+# The BIOS file (e.g., "F7A0110_sign.fd") or a directory containing it.
+, biosFile ? jupiter-hw-support.src
+
+# The BIOS version (e.g., "0110").
+# If null, parsed from the BIOS file name.
+, biosVersion ? null
+
+# The release date of the BIOS for the fwupd manifest.
+, releaseDate ? "1970-01-01"
+
+# The human-readable version for the package.
+, packageVersion ? jupiter-hw-support.src.version
+}:
+
+let
+  version = if packageVersion != null then packageVersion else jupiter-hw-support.version;
+
+in runCommand "steamdeck-bios-fwupd-${version}" {
+  inherit biosFile biosVersion releaseDate;
+
+  nativeBuildInputs = [ gcab ];
+
+  meta = with lib; {
+    description = "Steam Deck BIOS for fwupd";
+    license = licenses.unfreeRedistributableFirmware;
+  };
+} ''
+  if [[ -d "$biosFile" ]]; then
+    biosFile=$(find "$biosFile" -regextype posix-extended -type f -regex ".*/F7A.*_sign.fd" | head -1)
+  fi
+
+  >&2 echo ":: Found BIOS file $biosFile"
+
+  if [[ -z "$biosVersion" ]]; then
+    versionPair=$(basename "$biosFile" | sed 's/^.*F7A\([0-9]\{2\}\)\([0-9]\{2\}\).*$/\1 \2/; t; q1')
+  else
+    versionPair=$(echo "$biosVersion" | sed 's/^\([0-9]\{2\}\)\([0-9]\{2\}\)$/\1 \2/; t; q1')
+  fi
+
+  get_numeric_ver() { printf "%d" "0x00$100$2"; }
+  export versionNumber=$(get_numeric_ver $versionPair)
+
+  >&2 echo ":: Detected numeric BIOS version $versionNumber"
+
+  export filename=$(basename "$biosFile")
+  export sha1=$(sha1sum "$biosFile" | awk '{ print $1 }')
+  export sha256=$(sha1sum "$biosFile" | awk '{ print $1 }')
+  substituteAll ${./SteamDeckBIOS.metainfo.xml} SteamDeckBIOS.metainfo.xml
+
+  >&2 echo ":: Generated metainfo file"
+  cat -n SteamDeckBIOS.metainfo.xml
+
+  mkdir -p $out
+  cp "$biosFile" .
+  gcab -c $out/bios.cab SteamDeckBIOS.metainfo.xml "$filename"
+''

--- a/pkgs/jupiter-hw-support/firmware.nix
+++ b/pkgs/jupiter-hw-support/firmware.nix
@@ -1,0 +1,79 @@
+{ lib
+, stdenv
+, callPackage
+, autoPatchelfHook
+, makeWrapper
+, python3
+
+# jupiter-biosupdate
+, libkrb5
+, zlib
+, jq
+, dmidecode
+}:
+
+let
+  src = callPackage ./src.nix { };
+  pythonEnv = python3.withPackages (py: with py; [
+    crcmod
+    click
+    progressbar2
+    hid
+  ]);
+in
+stdenv.mkDerivation {
+  pname = "steamdeck-firmware";
+
+  inherit src;
+  inherit (src) version;
+
+  nativeBuildInputs = [
+    autoPatchelfHook
+    makeWrapper
+  ];
+
+  buildInputs = [
+    # auto patchelf
+    libkrb5
+    zlib
+    stdenv.cc.cc # libstdc++.so.6
+
+    pythonEnv
+  ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/{bin,share}
+    cp -r usr/share/jupiter_bios $out/share
+    cp -r usr/share/jupiter_bios_updater $out/share
+    cp -r usr/share/jupiter_controller_fw_updater $out/share
+
+    cp usr/bin/jupiter-biosupdate $out/bin
+    sed -i "s|/usr/|$out/|g" $out/bin/jupiter-biosupdate
+    wrapProgram $out/bin/jupiter-biosupdate \
+      --prefix PATH : ${lib.makeBinPath [ jq dmidecode ]}
+
+    cp usr/bin/jupiter-controller-update $out/bin
+    sed -i "s|/usr/|$out/|g" $out/bin/jupiter-controller-update
+    wrapProgram $out/bin/jupiter-controller-update \
+      --prefix PATH : ${lib.makeBinPath [ jq pythonEnv ]}
+
+    pushd $out/share/jupiter_bios_updater
+    # Upstream comment:
+    # > Remove gtk2 binary and respective build/start script - unused
+    # > Attempts to use gtk2 libraries which are not on the device.
+    rm h2offt-g H2OFFTx64-G.sh
+    popd
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Steam Deck BIOS and controller firmware";
+    license = licenses.unfreeRedistributableFirmware;
+  };
+}

--- a/pkgs/jupiter-hw-support/firmware.nix
+++ b/pkgs/jupiter-hw-support/firmware.nix
@@ -3,13 +3,17 @@
 , callPackage
 , autoPatchelfHook
 , makeWrapper
+, writeShellScript
 , python3
+, util-linux
 
 # jupiter-biosupdate
 , libkrb5
 , zlib
 , jq
 , dmidecode
+
+, efiSysMountPoint ? "/boot"
 }:
 
 let
@@ -20,6 +24,37 @@ let
     progressbar2
     hid
   ]);
+
+  # Very ugly wrapper to work around the hardcoded ESP path
+  h2offtWrapper = writeShellScript "h2offt-wrapper" ''
+    @h2offt@ "$@"
+    ret=$?
+
+    set -e
+
+    esp="${efiSysMountPoint}"
+
+    if [[ $ret = 194 && "$esp" != "/boot/efi" ]]; then
+      targetDir="$esp/EFI/Insyde"
+      source="/boot/efi/EFI/Insyde/isflash.bin"
+
+      >&2 echo "NixOS: Moving isflash.bin to $targetDir"
+
+      if [[ ! -e "$source" ]]; then
+        >&2 echo "NixOS: isflash.bin doesn't exist!"
+        exit 1
+      fi
+
+      ${util-linux}/bin/mountpoint "$esp" >/dev/null
+
+      mkdir -p "$targetDir"
+      mv "$source" "$targetDir"
+
+      >&2 echo "NixOS: Successfully moved"
+    fi
+
+    exit $ret
+  '';
 in
 stdenv.mkDerivation {
   pname = "steamdeck-firmware";
@@ -52,7 +87,13 @@ stdenv.mkDerivation {
     cp -r usr/share/jupiter_bios_updater $out/share
     cp -r usr/share/jupiter_controller_fw_updater $out/share
 
+    h2offt_nixos="$out/share/jupiter_bios_updater/h2offt-nixos"
+    h2offt="$out/share/jupiter_bios_updater/h2offt" \
+      substituteAll ${h2offtWrapper} "$h2offt_nixos"
+    chmod +x "$h2offt_nixos"
+
     cp usr/bin/jupiter-biosupdate $out/bin
+    sed -i "s|/usr/share/jupiter_bios_updater/h2offt|$h2offt_nixos|g" $out/bin/jupiter-biosupdate
     sed -i "s|/usr/|$out/|g" $out/bin/jupiter-biosupdate
     wrapProgram $out/bin/jupiter-biosupdate \
       --prefix PATH : ${lib.makeBinPath [ jq dmidecode ]}

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20220825.1";
+  version = "20221005.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-Xd8J6TiNbUXRGDAwqtvK1gdJPaaH+JMY1CbuHlddWEg=";
+  sha256 = "sha256-fjNRCclhGvF9YsUGri4gTVLD8KhtRr4dUCkQnU99oEo=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
(Builds on top of #21)

This PR adds the `steamdeck-firmware` package which contains the BIOS and controller firmware. Run `jupiter-biosupdate` to update the BIOS, and `jupiter-controller-update` to update the controller firmware.

Fixes #2 and #9.

<details>
<summary>Output from jupiter-biosupdate (with the manual patch to the version map)</summary>

```
Performing BIOS updates
BIOS version: F7A0107
Desired version: F7A0108
Running:  '/nix/store/d67fmhlbpml772pfr1nw5mb0xwz01khn-jupiter-hw-support-20220721.3-firmware/share/jupiter_bios_updater/h2offt' '/nix/store/d67fmhlbpml772pfr1nw5mb0xwz01khn-jupiter-hw-support-20220721.3-firmware/share/jupiter_bios/F7A0108_sign.fd' '-all' '-AC' '-N'
Read file successfully.  (path="platform.ini")
Read file successfully.  (path="msg_eng.ini")


         Insyde H2OFFT (Flash Firmware Tool) Version (SEG) 200.01.00.10
      Copyright(c) 2012 - 2020, Insyde Software Corp. All Rights Reserved.


                        Initializing

               Current BIOS Model name: CHACHANI-VANGOGH
               New     BIOS Model name: CHACHANI-VANGOGH

               Current BIOS version: F7A0107
               New     BIOS version: F7A0108


Will apply bios update to version F7A0108 after reboot
```
</details>

<details>
<summary>Output from jupiter-controller-update</summary>

```
PTS: 1658426874, STS: 1658426892
[
  {
    "path": "/dev/hidraw3",
    "vendor_id": 10462,  
    "product_id": 4613,  
    "serial_number": "REDACTED",
    "release_number": 512,
    "manufacturer_string": "Valve Software",
    "product_string": "Steam Deck Controller",  
    "usage_page": 65535, 
    "usage": 1,
    "interface_number": 2,
    "build_timestamp": 1658426874,
    "secondary_build_timestamp": 1658426892,
    "is_bootloader": false
  }
]
NO UPDATE: Type 1/2 Device is running latest build 1658426874
```
</details>

<details>
<summary>Output from jupiter-dock-updater</summary>

```
========================================
=   VLI Kinetic I2C Update Tool v0.0   =
=                                      =
=              Sherlock Chu            =
=               2022.03.28             =
========================================
    SPI-IMAGE: jaguar-b0_LUXSHARE_spi_image_V0.013.15.0.106_220920.bin Check OK
    ISP_DRIVER: jaguar-b0_mca_i2c_isp_driver_payload.bin Check OK
    ----- Setting From Setting.ini -----
    LogFile=0
    DeviceNum=1
    ReadVerOnly=0
    ReadBinOnly=0
    CheckUpdateOnly=0
    BackUpOnly=0
    I2CTestOnly=0
    KinetBin0=jaguar-b0_LUXSHARE_spi_image_V0.013.15.0.106_220920.bin
    KinetBin1=jaguar-b0_mca_i2c_isp_driver_payload.bin
    ------------------------------------
    ----- Setting From command.sh  -----
    Hub1VID=28DE
    Hub1PID=2001
    Hub1Bin=
    Bus=0
    Path=
    gHubPDShareSPI=0
    gReadVerOnly=0
    gReadBinOnly=0
    gCheckUpdateOnly=0
    gBackUpOnly=0
    ------------------------------------

   device vid :pid  bcdDevice      (address)    bus    path
----------------------------------------------------------------
( )000000 1d6b:0003 bcdDevice 0513 (address 01) bus 4,
( )000001 13d3:3553 bcdDevice 0000 (address 03) bus 3, path 5
( )000002 28de:1205 bcdDevice 0200 (address 02) bus 3, path 3
( )000003 1d6b:0002 bcdDevice 0513 (address 01) bus 3,
( )000004 0b95:1790 bcdDevice 0200 (address 21) bus 2, path 1.4
( )000005 2109:0817 bcdDevice 0724 (address 20) bus 2, path 1
( )000006 1d6b:0003 bcdDevice 0513 (address 01) bus 2,
(*)000007 28de:2001 bcdDevice 0001 (address 20) bus 1, path 1.5
( )000008 2109:2817 bcdDevice 0724 (address 19) bus 1, path 1
( )000009 1d6b:0002 bcdDevice 0513 (address 01) bus 1,
----------------------------------------------------------------
Kinet_Reg_Write 5000=0010
    read-loop = 0
Kinet_Reg_Write 5000=0011
    read-loop = 0
Kinet_Flash_Write FW1
TotalByte: 0x24C0 = 9 KB
progress=87%
Kinet_Reg_Write 5000=0012
    read-loop = 0
Kinet_Reg_Write 5000=0020
    read-loop = 1
Kinet_Flash_Write FW0
TotalByte: 0x100000 = 1024 KB
progress=99%
Kinet_Reg_Write 5000=0110
    read-loop = 0

===========================
= Kinetic_FW_Update_PASS. =
===========================
Status=0x1
```
</details>

<details>
<summary>Previous PR description</summary>

This PR adds the `jupiter-hw-support` package from SteamOS, which contains themes, utility scripts, as well as firmware updaters. The `firmware` output contains the BIOS and controller firmware. Run `jupiter-biosupdate` to update the BIOS, and `jupiter-controller-update` to update the controller firmware.

~~Note the firmware updaters are untested! My Deck comes with BIOS F7A0107 which isn't present in the [BIOS version map](https://github.com/Jovian-Experiments/jupiter-hw-support/blob/e32d0946cae1b6a5c5be32fbfd420c0ba6b27823/usr/bin/jupiter-biosupdate#L17-L38). Manually adding the version to the map allowed me to successfully stage the update, but the Steam Deck then stalled at the logo for 15 minutes upon reboot. Luckily powering off then on again allowed the Deck to boot again, but the BIOS remained at the original version. My controller firmware was updated automatically by the updater service while I was testing a vanilla Arch install with the `jupiter-hw-support` package.~~ Edit: They work fine now.
</details>