### PR TITLE
steamdeck/graphical: Tie enableDRMRotationParam's default to cfg.enable

### DIFF
--- a/modules/steamdeck/graphical.nix
+++ b/modules/steamdeck/graphical.nix
@@ -15,7 +15,7 @@ in
         type = lib.types.bool;
       };
       enableDRMRotationParam = lib.mkOption {
-        default = !cfg.hasKernelPatches;
+        default = cfg.enable && !cfg.hasKernelPatches;
         type = lib.types.bool;
       };
       enableXorgRotation = lib.mkOption {


### PR DESCRIPTION
Missed this one in #16. Now pulling in the module on my Framework Laptop no longer rotates my display by default.