### PR TITLE
linux-jovian: 5.13.0-valve21 -> 5.13.0-valve24

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,7 +9,7 @@ let
   ;
 
   kernelVersion = "5.13.0";
-  vendorVersion = "valve21";
+  vendorVersion = "valve24";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -66,6 +66,6 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-R5L698t7hJYRT63aAyLgXHJ1b0UnCwYYjEr2WIly11o=";
+    hash = "sha256-zTc6qmKImrn/ChtK1Fu3VhaKaeiGMLHakgIahKddTMs=";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
In particular, support for the Steam Deck controller was [added to the kernel hid-steam driver](https://github.com/Jovian-Experiments/linux/commit/72ce570d0b3ae23aaf74ae604d58a2c819d1b4a8) in valve23. It can now be used as a gamepad without having the Steam client open.