### PR TITLE
linux-jovian: 5.13.0-valve24 -> 5.13.0-valve25

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,13 +9,21 @@ let
   ;
 
   kernelVersion = "5.13.0";
-  vendorVersion = "valve24";
+  vendorVersion = "valve25";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
 
   # branchVersion needs to be x.y
   extraMeta.branch = versions.majorMinor version;
+
+  kernelPatches = [
+    # Valve forgot to update EXTRAVERSION - Remove for valve26
+    {
+      name = "valve25-extraversion";
+      patch = ./valve25-extraversion.patch;
+    }
+  ];
 
   structuredExtraConfig = with lib.kernel; {
     #
@@ -66,6 +74,6 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-zTc6qmKImrn/ChtK1Fu3VhaKaeiGMLHakgIahKddTMs=";
+    hash = "sha256-GKAZffSTbKGdjO5vHPVRKeVlXnw2w9jLDIaK6e3sqw8=";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/linux-jovian/valve25-extraversion.patch
+++ b/pkgs/linux-jovian/valve25-extraversion.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 0e5b8ecdd39e..bbc63783fcb4 100644
+--- a/Makefile
++++ b/Makefile
+@@ -2,7 +2,7 @@
+ VERSION = 5
+ PATCHLEVEL = 13
+ SUBLEVEL = 0
+-EXTRAVERSION =-valve24
++EXTRAVERSION =-valve25
+ NAME = Opossums on Parade
+ 
+ # *DOCUMENTATION*


### PR DESCRIPTION
Contains [a couple of fixes](https://github.com/Jovian-Experiments/linux/commits/5.13.0-valve25) for external displays/Docking Station.