### PR TITLE
acp5x-ucm: runCommandNoCC alias gone

### DIFF
--- a/pkgs/acp5x-ucm/default.nix
+++ b/pkgs/acp5x-ucm/default.nix
@@ -1,9 +1,9 @@
-{ runCommandNoCC }:
+{ runCommand }:
 
 let
   version = "jupiter-20220310.1000";
 in
-runCommandNoCC "acp5x-ucm-${version}" {
+runCommand "acp5x-ucm-${version}" {
   passthru = {
     inherit version;
   };


### PR DESCRIPTION
basic fix
