### PR TITLE
linux-jovian: Fix application of external patches

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -17,7 +17,7 @@ buildLinux (args // rec {
   # branchVersion needs to be x.y
   extraMeta.branch = versions.majorMinor version;
 
-  kernelPatches = [
+  kernelPatches = (args.kernelPatches or []) ++ [
     # Valve forgot to update EXTRAVERSION - Remove for valve26
     {
       name = "valve25-extraversion";


### PR DESCRIPTION
Without this, `boot.kernelPatches` ended-up being unused.

Why not add `kernelPatches` to the input of the callPackage definition here? Because it would need to be "pinned" in the `let` block to fight against the `rec` from the attrset.

Furthermore, this will reduce churn if/when we remove that block later.