### PR TITLE
jupiter-hw-support: 20221005.1 -> 20221010.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20221005.1";
+  version = "20221010.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-fjNRCclhGvF9YsUGri4gTVLD8KhtRr4dUCkQnU99oEo=";
+  sha256 = "sha256-OjrsUUrSQOxrdECyVSSRMelKZsgmI3pAwsipvcPSSzE=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
Contains a new [controller firmware update](https://github.com/Jovian-Experiments/jupiter-hw-support/commit/73997bd1c693940ab2fae4798be41109c0bf94a3).