### PR TITLE
jupiter-dock-updater-bin: 20220921.01 -> 20221026.01

### DIFF
--- a/pkgs/jupiter-dock-updater-bin/default.nix
+++ b/pkgs/jupiter-dock-updater-bin/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-dock-updater-bin";
-  version = "20220921.01";
+  version = "20221026.01";
 
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "jupiter-dock-updater-bin";
     rev = "jupiter-${version}";
-    hash = "sha256-rlHUHIaRBHK5KlCklPh0X0Is6D2sVhB6h6yMZZDRPUk=";
+    hash = "sha256-Iu9oAy9wVIMowD+wOABIbLjA0Vgr7xndlz0/jhuDuVg=";
   };
 
   buildInputs = [


### PR DESCRIPTION
Changes:

  - https://github.com/Jovian-Experiments/jupiter-dock-updater-bin/compare/jupiter-20220921.01...jupiter-20221026.01

Actual description of changes: unknowable.