### PR TITLE
default.nix: Override pulseaudio config

### DIFF
--- a/.ci/instantiate-iso.nix
+++ b/.ci/instantiate-iso.nix
@@ -1,0 +1,5 @@
+let
+  defaultNix = import ../default.nix { };
+in {
+  inherit (defaultNix) isoMinimal isoGnome isoPlasma;
+}

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -14,3 +14,6 @@ jobs:
 
       - name: Evaluate overlay packages
         run: nix-instantiate .ci/instantiate-overlay.nix
+
+      - name: Evaluate installation ISO
+        run: nix-instantiate .ci/instantiate-iso.nix

--- a/default.nix
+++ b/default.nix
@@ -12,9 +12,14 @@ let
       modules= [
         ./modules
         configuration
-        {
+        ({ lib, config, ... }: {
           jovian.devices.steamdeck.enable = true;
-        }
+
+          # Override config in installation-cd-graphical-base.nix
+          hardware.pulseaudio.enable = lib.mkIf
+            (config.jovian.devices.steamdeck.enableSoundSupport && config.services.pipewire.enable)
+            (lib.mkForce false);
+        })
       ];
     }
   ;


### PR DESCRIPTION
The mkIf is added defensively so it breaks loudly when we refactor `enableSoundSupport` in the future.

Fixes #34.