### PR TITLE
sdgyrodsu: init at unstable-2022-08-22, modules: Add sdgyrodsu

### DIFF
--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -29,9 +29,6 @@ in
     (mkIf (cfg.enableControllerUdevRules) {
       # Necessary for the controller parts to work correctly.
       services.udev.extraRules = ''
-        # This rule is needed to expose the hiddev devices for other applications
-        SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
-
         # This rule is needed by the vendor power-button-handler.py
         SUBSYSTEM=="input", ATTRS{phys}=="isa0060/serio0/input0", MODE="0660", TAG+="uaccess"
       '' + lib.optionalString (!config.hardware.steam-hardware.enable) ''

--- a/modules/steamdeck/default.nix
+++ b/modules/steamdeck/default.nix
@@ -19,6 +19,7 @@ in
     ./kernel.nix
     ./mesa.nix
     ./perf-control.nix
+    ./sdgyrodsu.nix
     ./sound.nix
   ];
 

--- a/modules/steamdeck/sdgyrodsu.nix
+++ b/modules/steamdeck/sdgyrodsu.nix
@@ -1,0 +1,46 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+  ;
+  cfg = config.jovian.devices.steamdeck;
+in
+{
+  options = {
+    jovian.devices.steamdeck = {
+      enableGyroDsuService = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable the Cemuhook DSU service for the gyroscope.
+
+          If enabled, motion data from the gyroscope can be used in Cemu
+          with Cemuhook.
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enableGyroDsuService {
+    systemd.services.sdgyrodsu = {
+      description = "Cemuhook DSU server for the Steam Deck Gyroscope";
+      wantedBy = [ "multi-user.target" ];
+      path = [ pkgs.usbutils ];
+      serviceConfig = {
+        DynamicUser = true;
+        SupplementaryGroups = [ "input" ];
+        ExecStart = "${pkgs.sdgyrodsu}/bin/sdgyrodsu";
+        PrivateTmp = true;
+        ProtectSystem = "strict";
+        ProtectHome = true;
+      };
+    };
+
+    services.udev.extraRules = ''
+      # This rule is needed to expose the hiddev devices to sdgyrodsu
+      SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="28de", MODE="0660", GROUP="input"
+    '';
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -40,4 +40,6 @@ in
       steam-fhsenv = scopeSuper.steam-fhsenv;
     };
   });
+
+  sdgyrodsu = final.callPackage ./pkgs/sdgyrodsu { };
 }

--- a/pkgs/sdgyrodsu/default.nix
+++ b/pkgs/sdgyrodsu/default.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, ncurses }:
+
+stdenv.mkDerivation {
+  pname = "sdgyrodsu";
+  version = "unstable-2022-08-22";
+
+  src = fetchFromGitHub {
+    owner = "kmicki";
+    repo = "SteamDeckGyroDSU";
+    rev = "6244cbc3ec55687efa9b6ade32d6c04637065003";
+    sha256 = "sha256-3hMSgFqNV9GyShwU0aB3tEpx82SUBHGl9jpYDYDua8k=";
+  };
+
+  buildInputs = [ ncurses ];
+
+  makeFlags = [ "NOPREPARE=1" "release" ];
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/bin
+    cp -r bin/release/sdgyrodsu $out/bin
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Cemuhook DSU server for the Steam Deck Gyroscope";
+    homepage = "https://github.com/kmicki/SteamDeckGyroDSU";
+    license = licenses.mit;
+  };
+}


### PR DESCRIPTION
This is a [DSU](https://v1993.github.io/cemuhook-protocol) server that exposes gyro data to emulators like Cemu and Dolphin. Tested to work with Cemu 2.0 (packaged [here](https://github.com/NixOS/nixpkgs/pull/198590)).

I was using it with Cemu 1.x + Cemuhook under Proton to play _Breath of the Wild_, which was bit janky but worked well enough. Now that the whole setup is much easier thanks to Cemu becoming open-source and a native version being available, I thought I should PR this.