### PR TITLE
jupiter-hw-support: 20221010.1 -> 20221102.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20221010.1";
+  version = "20221102.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-OjrsUUrSQOxrdECyVSSRMelKZsgmI3pAwsipvcPSSzE=";
+  sha256 = "sha256-9wBY8KYHzj+WSS5fhIQEtZrNMaA+XJXWIsL6J9+NXL4=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20221010.1...jupiter-20221102.1

Ran the controller updater:

```
[nix-shell:.../channels/jovian-nixos]$ sudo jupiter-controller-update 
PTS: 1658426874, STS: 1658426874
[
  {
    "path": "/dev/hidraw3",
    "vendor_id": 10462,
    "product_id": 4613,
    "serial_number": "",
    "release_number": 256,
    "manufacturer_string": "Valve Software",
    "product_string": "Steam Deck Controller",
    "usage_page": 65535,
    "usage": 1,
    "interface_number": 2,
    "build_timestamp": 1658426874,
    "secondary_build_timestamp": 1658426874,
    "is_bootloader": false
  }
]
UPDATE: Type 1 device is running build '1658426874', updating to build 1667423630
Found candidate device, build timestamp 1658426874, BL false, BL_Type 1, HYB false
Updating Type 1 System
2022-11-03 23:10:18,977 - __main__ - INFO - Looks like we are running an app. Resetting into bootloader
Switching to ISP mode: |                                                                                              
Erasing: |                                                                                                            
Programming: [########################################################################################] 177.5 KiB 100%
Waiting for app to enumerate: |                                                                                       
SUCCESS
Firmware updated to 1667423630
```

Haven't tested the UCM changes yet.