### PR TITLE
jupiter-fan-control: 20220705.1 -> 20221031.1

### DIFF
--- a/pkgs/jupiter-fan-control/default.nix
+++ b/pkgs/jupiter-fan-control/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-fan-control";
-  version = "20220705.1";
+  version = "20221031.1";
 
   # TODO: Replace with https://gitlab.steamos.cloud/jupiter/jupiter-fan-control
   # once it becomes public
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "Jovian-Experiments";
     repo = "jupiter-fan-control";
     rev = version;
-    sha256 = "sha256-Ij4yflupmlatbMFhGLUNv0bHo9H4tRlk2IX6pwnRFMk=";
+    sha256 = "sha256-5+6uHt1ykUtB8cJj6T5h0L9N2lPSkWsZS6U2+iO/WYc=";
   };
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/Jovian-Experiments/jupiter-fan-control/compare/20220705.1...20221031.1

I didn't re-enable stdout in our module since the logspam still exists (nothing in their changes adjusted it).