### PR TITLE
Misc udev fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,6 @@ Then you can start the UI using one of the following methods:
 - Select "Gaming Mode" in the Display Manager or run `steam-session` in a VT.
 - Launch `steam-session` within an existing desktop session. This will run [gamescope](https://github.com/Plagman/gamescope) in nested mode which results in higher latency.
 
-If you find power button not working in `steam-session`, add "input" to your [users.users.\<name\>.extraGroups](https://nixos.org/manual/nixos/stable/options.html#opt-users.users._name_.extraGroups).
-
 Firmware Updates
 ----------------
 

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -263,6 +263,7 @@ in
 
       hardware.opengl.driSupport32Bit = true;
       hardware.pulseaudio.support32Bit = true;
+      hardware.steam-hardware.enable = mkDefault true;
 
       environment.systemPackages = [ steam-session ];
 

--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -31,6 +31,9 @@ in
       services.udev.extraRules = ''
         # This rule is needed to expose the hiddev devices for other applications
         SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
+
+        # This rule is needed by the vendor power-button-handler.py
+        SUBSYSTEM=="input", ATTRS{phys}=="isa0060/serio0/input0", MODE="0660", TAG+="uaccess"
       '' + lib.optionalString (!config.hardware.steam-hardware.enable) ''
         # This rule is necessary for gamepad emulation.
         KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -30,13 +30,13 @@ in
       # Necessary for the controller parts to work correctly.
       services.udev.extraRules = ''
         # This rule is necessary for gamepad emulation.
-        KERNEL=="uinput", MODE="0660", GROUP="users", OPTIONS+="static_node=uinput"
+        KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
 
         # This rule is needed for basic functionality of the controller in Steam and keyboard/mouse emulation
-        SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0666"
+        SUBSYSTEM=="usb", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
 
         # Valve HID devices over USB hidraw
-        KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0666"
+        KERNEL=="hidraw*", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
       '';
     })
   ];

--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -29,6 +29,9 @@ in
     (mkIf (cfg.enableControllerUdevRules) {
       # Necessary for the controller parts to work correctly.
       services.udev.extraRules = ''
+        # This rule is needed to expose the hiddev devices for other applications
+        SUBSYSTEM=="usbmisc", ATTRS{idVendor}=="28de", MODE="0660", TAG+="uaccess"
+      '' + lib.optionalString (!config.hardware.steam-hardware.enable) ''
         # This rule is necessary for gamepad emulation.
         KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
 


### PR DESCRIPTION
- Use `TAG+="uaccess"` to grant access to active users instead of `MODE="0666"`. More in line with best practices.
- Enable the vendor udev rules by default when `jovian.steam` is enabled. The vendor rules contain support for more third-party controllers.
- Add a udev rule for the power button needed by the vendor `power-button-handler.py`. It's no longer required to add the user to the input group.