### PR TITLE
jupiter-fan-control: 20221031.1 -> 20221107.1

### DIFF
--- a/pkgs/jupiter-fan-control/default.nix
+++ b/pkgs/jupiter-fan-control/default.nix
@@ -2,7 +2,7 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-fan-control";
-  version = "20221031.1";
+  version = "20221107.1";
 
   # TODO: Replace with https://gitlab.steamos.cloud/jupiter/jupiter-fan-control
   # once it becomes public
@@ -10,7 +10,7 @@ stdenv.mkDerivation rec {
     owner = "Jovian-Experiments";
     repo = "jupiter-fan-control";
     rev = version;
-    sha256 = "sha256-5+6uHt1ykUtB8cJj6T5h0L9N2lPSkWsZS6U2+iO/WYc=";
+    sha256 = "sha256-i/wSbFRGAhlrFKCKmFRpgljkqZ3m9TkfWVS4HNGwVbU=";
   };
 
   buildInputs = [


### PR DESCRIPTION
https://github.com/Jovian-Experiments/jupiter-fan-control/compare/20221031.1...20221107.1

Technically we don't need to upgrade... Since anyway we use our own service definition

 - https://github.com/Jovian-Experiments/Jovian-NixOS/blob/d0d0bbd4bcc9ea9e5d5ddd85d0da13796a729b84/modules/steamdeck/fan-control.nix#L40-L41