### PR TITLE
jupiter-hw-support: 20221102.1 -> 20221108.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20221102.1";
+  version = "20221108.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-9wBY8KYHzj+WSS5fhIQEtZrNMaA+XJXWIsL6J9+NXL4=";
+  sha256 = "sha256-qb/YOWsBm213ChTM05XCehtX2zhYvXVxOgUMfdJpE9E=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20221102.1...jupiter-20221108.1

Changes to the controller firmware. I updated, it updated successfully.