### PR TITLE
linux_jovian_6_0: init at 6.0.9-valve1

### DIFF
--- a/modules/steamdeck/fan-control.nix
+++ b/modules/steamdeck/fan-control.nix
@@ -11,6 +11,10 @@ let
     types
   ;
   cfg = config.jovian.devices.steamdeck;
+
+  jupiter-fan-control = pkgs.jupiter-fan-control.override {
+    useNewHwmonName = config.boot.kernelPackages.kernel.meta.branch == "6.0";
+  };
 in
 {
   options = {
@@ -32,8 +36,8 @@ in
       wantedBy = [ "multi-user.target" ];
       path = [ pkgs.dmidecode ];
       serviceConfig = {
-        ExecStart = "${pkgs.jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --run";
-        ExecStopPost = "${pkgs.jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --stop";
+        ExecStart = "${jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --run";
+        ExecStopPost = "${jupiter-fan-control}/share/jupiter-fan-control/fancontrol.py --stop";
         OOMScoreAdjust = -1000;
         Restart = "on-failure";
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -20,6 +20,15 @@ in
     ];
   };
 
+  linuxPackages_jovian_6_0 = linuxPackagesFor final.linux_jovian_6_0;
+  linux_jovian_6_0 = super.callPackage ./pkgs/linux-jovian/6_0.nix {
+    kernelPatches = [
+      kernelPatches.bridge_stp_helper
+      kernelPatches.request_key_helper
+      kernelPatches.export-rt-sched-migrate
+    ];
+  };
+
   mangohud = final.callPackage ./pkgs/mangohud {
     inherit (super) mangohud;
   };

--- a/pkgs/jupiter-fan-control/default.nix
+++ b/pkgs/jupiter-fan-control/default.nix
@@ -1,4 +1,6 @@
-{ lib, stdenv, python3, fetchFromGitHub }:
+{ lib, stdenv, python3, fetchFromGitHub
+, useNewHwmonName ? false # Use "steamdeck_hwmon" as the hwmon name instead of "jupiter"
+}:
 
 stdenv.mkDerivation rec {
   pname = "jupiter-fan-control";
@@ -28,6 +30,10 @@ stdenv.mkDerivation rec {
     mkdir -p $out/share
     cp -r usr/share/jupiter-fan-control $out/share
     sed -i "s|/usr/share/|$out/share/|g" $out/share/jupiter-fan-control/fancontrol.py
+
+    ${lib.optionalString useNewHwmonName ''
+    sed -i "s|fan_hwmon_name: jupiter|fan_hwmon_name: steamdeck_hwmon|g" $out/share/jupiter-fan-control/jupiter-fan-control-config.yaml
+    ''}
 
     runHook postInstall
   '';

--- a/pkgs/linux-jovian/6_0.nix
+++ b/pkgs/linux-jovian/6_0.nix
@@ -8,7 +8,7 @@ let
     versions
   ;
 
-  kernelVersion = "6.0.6";
+  kernelVersion = "6.0.9";
   vendorVersion = "valve1";
 in
 buildLinux (args // rec {
@@ -62,6 +62,6 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = "${kernelVersion}-${vendorVersion}";
-    hash = "sha256-bRlDDEIe0OHV1NrB7BxyGee/EDAOiH+KnytHIrH6W7k=";
+    hash = "sha256-YdAMyLlN9Nf5lvlaNRaDVErtZvA+43oswj0taMNP6e4=";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/linux-jovian/6_0.nix
+++ b/pkgs/linux-jovian/6_0.nix
@@ -1,0 +1,67 @@
+{ lib, fetchFromGitHub, buildLinux, ... } @ args:
+
+let
+  inherit (lib)
+    concatStringsSep
+    splitVersion
+    take
+    versions
+  ;
+
+  kernelVersion = "6.0.6";
+  vendorVersion = "valve1";
+in
+buildLinux (args // rec {
+  version = "${kernelVersion}-${vendorVersion}";
+
+  # branchVersion needs to be x.y
+  extraMeta.branch = versions.majorMinor version;
+
+  structuredExtraConfig = with lib.kernel; {
+    #
+    # From the downstream packaging
+    # -----------------------------
+    #
+
+    ##
+    ## Neptune stuff
+    ##
+
+    # Doesn't build on latest tag, not used in neptune hardware (?)
+    SND_SOC_CS35L36 = no;
+    # Update this to  = yes to workaround initialization issues and deadlocks when loaded as module;
+    # The cs35l41 / acp5x drivers in EV2 fail IRQ initialization with this set to  = yes, changed back
+    SPI_AMD = module;
+
+    # Works around issues with the touchscreen driver
+    PINCTRL_AMD = yes;
+
+    SND_SOC_AMD_ACP5x = module;
+    SND_SOC_AMD_VANGOGH_MACH = module;
+    SND_SOC_WM_ADSP = module;
+    SND_SOC_CS35L41 = module;
+    SND_SOC_CS35L41_SPI = module;
+    SND_SOC_NAU8821 = module;
+
+    # Enable Ambient Light Sensor
+    LTRF216A = module;
+
+    # STEAMDECK modules are implicitly enabled (m)
+
+    HYPERVISOR_GUEST = lib.mkForce no;
+    KVM_GUEST = lib.mkForce (option no);
+
+    #
+    # Fallout from the vendor-set options
+    # -----------------------------------
+    #
+    MOUSE_PS2_VMMOUSE = lib.mkForce (option no);
+  };
+
+  src = fetchFromGitHub {
+    owner = "Jovian-Experiments";
+    repo = "linux";
+    rev = "${kernelVersion}-${vendorVersion}";
+    hash = "sha256-bRlDDEIe0OHV1NrB7BxyGee/EDAOiH+KnytHIrH6W7k=";
+  };
+} // (args.argsOverride or { }))

--- a/pkgs/linux-jovian/6_0.nix
+++ b/pkgs/linux-jovian/6_0.nix
@@ -49,12 +49,13 @@ buildLinux (args // rec {
     # STEAMDECK modules are implicitly enabled (m)
 
     HYPERVISOR_GUEST = lib.mkForce no;
-    KVM_GUEST = lib.mkForce (option no);
 
     #
     # Fallout from the vendor-set options
     # -----------------------------------
     #
+    KVM_GUEST = lib.mkForce (option no);
+    DRM_HYPERV = lib.mkForce (option no);
     MOUSE_PS2_VMMOUSE = lib.mkForce (option no);
   };
 


### PR DESCRIPTION
[Released (.tar.gz)](https://steamdeck-packages.steamos.cloud/archlinux-mirror/sources/jupiter-main/linux-neptune-60-6.0.6.valve1-2.src.tar.gz) in the jupiter-main pacman repo, so probably a good time to add it here as well.
