### PR TITLE
mangohud: init at unstable-2022-09-18

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -20,6 +20,10 @@ in
     ];
   };
 
+  mangohud = final.callPackage ./pkgs/mangohud {
+    inherit (super) mangohud;
+  };
+
   mesa-radv-jupiter = final.callPackage ./pkgs/mesa-radv-jupiter { };
 
   jupiter-fan-control = final.callPackage ./pkgs/jupiter-fan-control { };

--- a/pkgs/mangohud/default.nix
+++ b/pkgs/mangohud/default.nix
@@ -1,0 +1,13 @@
+{ mangohud, fetchFromGitHub }:
+
+mangohud.overrideAttrs (old: {
+  version = "unstable-2022-09-18";
+  src = fetchFromGitHub {
+    owner = "flightlessmango";
+    repo = "MangoHud";
+
+    # As shipped in SteamOS 3 repo 0.6.8.r17.gebb0f96
+    rev = "ebb0f969dea2c5df1600e6e299cd5665920e0020";
+    hash = "sha256-+luu/YjSNdhUl3TDyNrsvSiZOL3Jpfx0wv3MPe+vtyQ=";
+  };
+})


### PR DESCRIPTION
Let's overlay `mangohud` again, because [the latest client beta](https://www.gamingonlinux.com/2022/11/steamos-34-rolls-out-in-beta-for-the-steam-deck-its-a-massive-upgrade) uses horizontal mode for Level 2 of the Performance Overlay which is only supported in an unstable version of `mangohud`.

![mangohud-horizontal](https://user-images.githubusercontent.com/2189609/201544789-58a30776-3af0-4058-954a-daf101ae1d0e.jpg)
