### PR TITLE
jupiter-hw-support: 20221121.1 -> 20221213.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20221121.1";
+  version = "20221213.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-gFa0NgKQJSliaG57MF6im9Z27CXCjXu/zVQWyRan58A=";
+  sha256 = "sha256-0cHS2RU3qYmE2vfRm280jAU82c+OoZ4V5LBoSbqYXu0=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
New BIOS update (113). Tested updating with the fwupd package.

https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20221121.1...jupiter-20221213.1