### PR TITLE
mesa-radv-jupiter: jupiter-22.3.3 -> jupiter-22.3.4

### DIFF
--- a/pkgs/mesa-radv-jupiter/default.nix
+++ b/pkgs/mesa-radv-jupiter/default.nix
@@ -30,7 +30,7 @@ with lib;
 
 let
   version = "22.2.0";
-  jupiterVersion = "jupiter-22.3.3";
+  jupiterVersion = "jupiter-22.3.4";
 
 self = stdenv.mkDerivation {
   pname = "mesa-radv-jupiter";
@@ -40,7 +40,7 @@ self = stdenv.mkDerivation {
     owner = "Jovian-Experiments";
     repo = "mesa";
     rev = jupiterVersion;
-    hash = "sha256-KyRh8CSJfHGg3vtjfvNxUN0WwIbdX34KkbwHNx1URcM=";
+    hash = "sha256-dlkhuX4+/iJDiFw1P7kmul0rxGjygO2IKBhrGc3ufhc=";
   };
 
   # TODO:


### PR DESCRIPTION
This supposedly [fixes](https://github.com/Jovian-Experiments/mesa/commit/a399477fa20303558436e3828c7737641f5a536f) _Death Stranding Director's Cut_ ([gamingonlinux](https://www.gamingonlinux.com/2022/12/steam-deck-os-34-gets-a-death-stranding-fix-plus-new-client-beta-and-firmware-update)), but I don't have the game to test.

https://github.com/Jovian-Experiments/mesa/compare/jupiter-22.3.3...jupiter-22.3.4