### PR TITLE
linux-jovian: 5.13.0-valve35 -> 5.13.0-valve36

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,7 +9,7 @@ let
   ;
 
   kernelVersion = "5.13.0";
-  vendorVersion = "valve35";
+  vendorVersion = "valve36";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -84,6 +84,6 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-Giinyo3DbX50UfHOZE4zEZwHB5UBnYxce9qeGh59XDY=";
+    hash = "sha256-UdH738KVUwKm2JZVnAwJuQoy2sYQVdleFn0mXmWx5H4=";
   };
 } // (args.argsOverride or { }))


### PR DESCRIPTION
https://github.com/Jovian-Experiments/linux/compare/5.13.0-valve35...5.13.0-valve36

> Steam Deck OS 3.4 Preview Update: Why Buffer
>
> Fixed an audio driver bug that could lead to on-board audio crackling in some situations

&mdash; https://steamcommunity.com/games/1675200/announcements/detail/5201125680698748300