### PR TITLE
linux-jovian: Work around regression with SEV configs enabled

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -78,6 +78,13 @@ buildLinux (args // rec {
     #
     KVM_GUEST = lib.mkForce (option no);
     MOUSE_PS2_VMMOUSE = lib.mkForce (option no);
+
+    # Workaround for regression with AMD SEV configs enabled
+    # https://github.com/NixOS/nixpkgs/pull/203908#issuecomment-1360956830
+    CRYPTO_DEV_CCP = lib.mkForce no;
+    AMD_MEM_ENCRYPT = lib.mkForce no;
+    KVM_AMD_SEV = lib.mkForce (option no);
+    SEV_GUEST = lib.mkForce (option no);
   };
 
   src = fetchFromGitHub {


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/203908#issuecomment-1360956830

Another user observed that stage-1 hung just after loading `amdgpu` with the stock NixOS stage-1. My Mobile NixOS stage-1 would hang, but I had no output due to using `fbcon=vc:2-6`. It is assumed it hung at the same moral place, when loading `amdgpu` for early KMS.

Disabling those options (returning to the previous config, verified from `/proc/config.gz`) fixes boot.