### PR TITLE
steamdeck: Set `enableRedistributableFirmware`

### DIFF
--- a/modules/steamdeck/hw-support.nix
+++ b/modules/steamdeck/hw-support.nix
@@ -31,6 +31,10 @@ in
   };
 
   config = mkMerge [
+    (mkIf (cfg.enable) {
+      # Firmware is required in stage-1 for early KMS.
+      hardware.enableRedistributableFirmware = true;
+    })
     (mkIf (cfg.enableDefaultStage1Modules) {
       boot.initrd.kernelModules = [
         "hid-generic"


### PR DESCRIPTION
When installing within expectations of the default NixOS install semantics, one would end-up with
`nixos/modules/installer/scan/not-detected.nix` imported in their config. This, in turn, turns on `enableRedistributableFirmware`.

Turn this on by default for users that don't end-up using `nixos-generate-config`. Otherwise, early KMS will fail.