### PR TITLE
jupiter-dock-updater-bin: 20221026.01 -> 20230126.01

### DIFF
--- a/pkgs/jupiter-dock-updater-bin/default.nix
+++ b/pkgs/jupiter-dock-updater-bin/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-dock-updater-bin";
-  version = "20221026.01";
+  version = "20230126.01";
 
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "jupiter-dock-updater-bin";
     rev = "jupiter-${version}";
-    hash = "sha256-Iu9oAy9wVIMowD+wOABIbLjA0Vgr7xndlz0/jhuDuVg=";
+    hash = "sha256-b60A3KQX+Y1J/X4/VMMMINaS6SYF/jjaINXoaVCrnUM=";
   };
 
   buildInputs = [


### PR DESCRIPTION
> *No known changelog*

YMMV.

Using a display with an HDMI to DP adapter now doesn't work at all. Proper DP works, HDMI works.

While doing the update, the updater failed and put itself in a situation where the dock wouldn't accept an update. If this happens, it seems that disconnecting everything from the dock including power and the deck, rebooting, connecting only power and the deck, and running the installer will likely work. Unsure what happened.

It is relatively safe to update to try as you **can** go back. I had to go back as otherwise I couldn't use the dock with dual displays anymore.

This is why this is setup as a draft pull request: it is unclear if this is actually better than the previous release of the firmware.