### PR TITLE
steam-jupiter: Force the -steamdeck argument for the correct client version

### DIFF
--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -78,5 +78,11 @@ let
     extraProfile = (args.extraProfile or "") + ''
       export PATH=${passthroughSudo}/bin:$PATH
     '';
+
+    # We need to add this flag when Steam is started directly (e.g., desktop mode)
+    # so we have the correct client version. This is important even for desktop
+    # use because only the Steam Deck branch of the client has the new on-screen
+    # keyboard that's summoned with STEAM + X.
+    extraArgs = "-steamdeck";
   });
 in wrappedSteam


### PR DESCRIPTION
`extraArgs` was upstreamed in https://github.com/NixOS/nixpkgs/pull/182641