### PR TITLE
mesa-radv-jupiter: jupiter-22.3.4 -> steamos-3.5.1

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,8 +1,8 @@
 # Arbitrary known-good revision for default use.
 let
-  revision = "0591d6b57bfeb55dfeec99a671843337bc2c3323";
+  revision = "3c5319ad3aa51551182ac82ea17ab1c6b0f0df89";
 in
 import (builtins.fetchTarball {
   url = "https://github.com/NixOS/nixpkgs/archive/${revision}.tar.gz";
-  sha256 = "sha256:14b02qjbcb8cgfy7hldk45zd8agsqvfccfhs4bq0yk1rqd0ixd2d";
+  sha256 = "sha256:0s6vyyfmhcyqrgln304c1490spb2hqhh5bzfi0y2hnk5i5sph07q";
 })


### PR DESCRIPTION
Bumped `mesa-radv-jupiter` to `steamos-3.5.1` (see [upstream changelogs](https://github.com/Jovian-Experiments/mesa/blob/steamos-3.5.1/docs/relnotes/steamos-3.5.0.rst), based on Mesa 23.1.0) and rebased the gamescope integration patch on top of Mesa 22.3 so it can be used on the latest `nixos-unstable`.

Tested launching the following games:

- Hades
- GTA V
- Cult of the Lamb

The framerate limiter seems to be working, and `strace` does show the patched Mesa reading `GAMESCOPE_LIMITER_FILE`.