### PR TITLE
jupiter-hw-support: 20221213.1 -> 20230201

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20221213.1";
+  version = "20230201";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-0cHS2RU3qYmE2vfRm280jAU82c+OoZ4V5LBoSbqYXu0=";
+  sha256 = "sha256-UwdkEvohPp/y2DXElAeWxFAH6C9No6ZG6SGr33fY220=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20221213.1...jupiter-20230201

There are some UCM changes (tested with #49) as well as new controller firmware.