### PR TITLE
steamdeck: Add fwupd remote for BIOS updates

### DIFF
--- a/modules/steamdeck/default.nix
+++ b/modules/steamdeck/default.nix
@@ -14,6 +14,7 @@ in
   imports = [
     ./controller.nix
     ./fan-control.nix
+    ./firmware.nix
     ./graphical.nix
     ./hw-support.nix
     ./kernel.nix

--- a/modules/steamdeck/firmware.nix
+++ b/modules/steamdeck/firmware.nix
@@ -1,0 +1,44 @@
+# BIOS/Firmware updates
+
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.jovian.devices.steamdeck;
+in
+{
+  options = {
+    jovian.devices.steamdeck = {
+      enableFwupdBiosUpdates = mkOption {
+        type = types.bool;
+        default = cfg.enable;
+        description = ''
+          Whether to use fwupd to update the BIOS.
+        '';
+      };
+    };
+  };
+
+  config = mkMerge [
+    (mkIf (cfg.enableFwupdBiosUpdates) {
+      services.fwupd.enable = true;
+
+      environment.etc."fwupd/remotes.d/steamdeck-bios.conf".text = ''
+        # Enabled by jovian.devices.steamdeck.enableFwupdBiosUpdates
+
+        [fwupd Remote]
+        Enabled=true
+        Title=Steam Deck BIOS
+        Keyring=none
+        MetadataURI=file://${pkgs.steamdeck-bios-fwupd}
+        ApprovalRequired=false
+      '';
+    })
+  ];
+}


### PR DESCRIPTION
This PR adds a fwupd remote pointing at our [repacked BIOS .cab](https://github.com/Jovian-Experiments/Jovian-NixOS/blob/d01c84e6e654685d202b11d16d65e4938521361c/pkgs/jupiter-hw-support/bios-fwupd.nix) so the BIOS update can be applied more easily. Tested by updating to F7A0115 with `fwupdmgr update`.

Note that the current fwupd in nixos-unstable is broken and needs https://github.com/NixOS/nixpkgs/pull/225354.