### PR TITLE
linux-jovian: Fix xpad driver for wired xbox 360 controller

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -1,4 +1,4 @@
-{ lib, fetchFromGitHub, buildLinux, ... } @ args:
+{ lib, fetchFromGitHub, fetchpatch, buildLinux, ... } @ args:
 
 let
   inherit (lib)
@@ -18,6 +18,13 @@ buildLinux (args // rec {
   extraMeta.branch = versions.majorMinor version;
 
   kernelPatches = (args.kernelPatches or []) ++ [
+    {
+      name = "0001-Input-xpad-Fix-NULL-deref-on-unitialized-dev.patch";
+      patch = (fetchpatch {
+        url = "https://github.com/samueldr/linux/commit/f3c15b9f79dba009711e683e7f3b4636a30a7749.patch";
+        sha256 = "sha256-UOpTLSoyrfL4eG8HiCYPegVXY5tRFv6JiP9LZuzeFXs=";
+      });
+    }
   ];
 
   structuredExtraConfig = with lib.kernel; {


### PR DESCRIPTION
This fixes a regression in the vendor kernel.

See:

 - https://github.com/samueldr/linux/commit/f3c15b9f79dba009711e683e7f3b4636a30a7749

Before the change, the USB stack would crash and burn.

```
Apr 15 19:35:29 dashdingo kernel: BUG: kernel NULL pointer dereference, address: 0000000000000270
Apr 15 19:35:29 dashdingo kernel: #PF: supervisor read access in kernel mode
Apr 15 19:35:29 dashdingo kernel: #PF: error_code(0x0000) - not-present page
Apr 15 19:35:29 dashdingo kernel: PGD 0 P4D 0 
Apr 15 19:35:29 dashdingo kernel: Oops: 0000 [#1] PREEMPT SMP NOPTI
Apr 15 19:35:29 dashdingo kernel: CPU: 3 PID: 812 Comm: (udev-worker) Not tainted 6.1.21-valve1 #1-NixOS
Apr 15 19:35:29 dashdingo kernel: Hardware name: Valve Jupiter/Jupiter, BIOS F7A0115 03/17/2023
Apr 15 19:35:29 dashdingo kernel: RIP: 0010:__dev_printk+0x16/0x67
Apr 15 19:35:29 dashdingo kernel: Code: 2b 14 25 28 00 00 00 74 05 e8 86 df 00 00 c9 c3 cc cc cc cc 0f 1f 44 00 00 41 55 41 54 49 89 d4 55 48 89 fd 53 48 85 f6 74 3c <4c> 8b 6e 50 48 89 f3 4d 85 ed 75 03 4c 8b 2e 48 89 df e8 73 b0 d0
Apr 15 19:35:29 dashdingo kernel: RSP: 0018:ffffb2b38118fb60 EFLAGS: 00010202
Apr 15 19:35:29 dashdingo kernel: RAX: ffffb2b38118fbb8 RBX: 000000000000000d RCX: 0000000000000000
Apr 15 19:35:29 dashdingo kernel: RDX: ffffb2b38118fb88 RSI: 0000000000000220 RDI: ffffffffbae352d9
Apr 15 19:35:29 dashdingo kernel: RBP: ffffffffbae352d9 R08: 0000000000000000 R09: 0000000000000000
Apr 15 19:35:29 dashdingo kernel: R10: 0000000000000220 R11: 0000000000000001 R12: ffffb2b38118fb88
Apr 15 19:35:29 dashdingo kernel: R13: ffff9315c3218000 R14: ffff93158c0438a8 R15: ffff9315c3218178
Apr 15 19:35:29 dashdingo kernel: FS:  00007efe9d616c80(0000) GS:ffff9318b00c0000(0000) knlGS:0000000000000000
Apr 15 19:35:29 dashdingo kernel: CS:  0010 DS: 0000 ES: 0000 CR0: 0000000080050033
Apr 15 19:35:29 dashdingo kernel: CR2: 0000000000000270 CR3: 000000013b4e2000 CR4: 0000000000350ee0
Apr 15 19:35:29 dashdingo kernel: Call Trace:
Apr 15 19:35:29 dashdingo kernel:  <TASK>
Apr 15 19:35:29 dashdingo kernel:  _dev_warn+0x79/0x94
Apr 15 19:35:29 dashdingo kernel:  xpad_probe.cold+0x19/0x1e [xpad]
Apr 15 19:35:29 dashdingo kernel:  usb_probe_interface+0xdf/0x2b0 [usbcore]
Apr 15 19:35:29 dashdingo kernel:  really_probe+0xdb/0x380
Apr 15 19:35:29 dashdingo kernel:  ? pm_runtime_barrier+0x50/0x90
Apr 15 19:35:29 dashdingo kernel:  __driver_probe_device+0x78/0x170
Apr 15 19:35:29 dashdingo kernel:  driver_probe_device+0x1f/0x90
Apr 15 19:35:29 dashdingo kernel:  __driver_attach+0xce/0x1c0
Apr 15 19:35:29 dashdingo kernel:  ? __device_attach_driver+0x110/0x110
Apr 15 19:35:29 dashdingo kernel:  bus_for_each_dev+0x84/0xd0
Apr 15 19:35:29 dashdingo kernel:  bus_add_driver+0x1ae/0x200
Apr 15 19:35:29 dashdingo kernel:  driver_register+0x89/0xe0
Apr 15 19:35:29 dashdingo kernel:  usb_register_driver+0x84/0x120 [usbcore]
Apr 15 19:35:29 dashdingo kernel:  ? 0xffffffffc194e000
Apr 15 19:35:29 dashdingo kernel:  do_one_initcall+0x56/0x220
Apr 15 19:35:29 dashdingo kernel:  do_init_module+0x4a/0x1e0
Apr 15 19:35:29 dashdingo kernel:  __do_sys_init_module+0x17f/0x1b0
Apr 15 19:35:29 dashdingo kernel:  do_syscall_64+0x37/0x90
Apr 15 19:35:29 dashdingo kernel:  entry_SYSCALL_64_after_hwframe+0x63/0xcd
Apr 15 19:35:29 dashdingo kernel: RIP: 0033:0x7efe9d5100be
```

After the change:

```
[   26.358227] xpad 1-1.2:1.0: unable to receive magic message: -32
```

As expected.