### PR TITLE
linux-firmware: jupiter-20230110 -> jupiter-20230420

### DIFF
--- a/pkgs/linux-firmware/default.nix
+++ b/pkgs/linux-firmware/default.nix
@@ -4,9 +4,9 @@ linux-firmware.overrideAttrs(_: {
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "linux-firmware";
-    rev = "jupiter-20230110";
-    hash = "sha256-XHdqeWYYlobqCr53wc9GvBiMpzzOgEP785R5YhoCIwI=";
+    rev = "jupiter-20230420";
+    hash = "sha256-ys/7G+JsiuKQo9aL5MZjs4NxqDjK2bdJkLRJaoNeIDM=";
   };
 
-  outputHash = "sha256-v66fhA2WdYgrOLxEC6IHA6wDv9T5vLJV81DJq/sbMA0=";
+  outputHash = "sha256-eEeBS95gI7G9KVpc9boqRAdecrPc0EsfFD2nhh63fCY=";
 })


### PR DESCRIPTION
Hard to list changes, since there was a sync with upstream since.

 - https://github.com/Jovian-Experiments/linux-firmware/compare/jupiter-20230110...jupiter-20230420

I think we missed at least one update, too.