### PR TITLE
jupiter-hw-support: 20230327.1 -> 20230424.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20230327.1";
+  version = "20230424.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  sha256 = "sha256-kAxkvsRawQWty2aW1EDrpUy25pvOhp3jIFBSyPvHVjM=";
+  sha256 = "sha256-NlAhfDL1bRy6qj3jM8hHiZOWlaLhi/Q0rdGbMpDDNQg=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
 - https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20230327.1...jupiter-20230424.1

Only notable change here is the presence of a controller firmware update.