### PR TITLE
linux-jovian+gamescope: Update to 20230516.1000 feature level

### DIFF
--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -367,6 +367,15 @@ in
         # Enable VRR controls in steam
         STEAM_GAMESCOPE_VRR_SUPPORTED = "1";
 
+        # Scaling support
+        STEAM_GAMESCOPE_FANCY_SCALING_SUPPORT = "1";
+
+        # Color management support
+        STEAM_GAMESCOPE_COLOR_MANAGED = "1";
+
+        # Enable HDR support in steam
+        STEAM_GAMESCOPE_HDR_SUPPORTED = "1";
+
         # Set refresh rate range and enable refresh rate switching
         STEAM_DISPLAY_REFRESH_LIMITS = "40,60";
 

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -340,6 +340,9 @@ in
         # Disable automatic audio device switching in steam, now handled by wireplumber
         STEAM_DISABLE_AUDIO_DEVICE_SWITCHING = "1";
 
+        # Let steam know it can unmount drives without superuser privileges
+        STEAM_ALLOW_DRIVE_UNMOUNT = "1";
+
         # Enable support for xwayland isolation per-game in Steam
         STEAM_MULTIPLE_XWAYLANDS = "1";
 
@@ -402,6 +405,9 @@ in
       jovian.steam.environment = {
         # Enable dynamic backlight, we have the kernel patch to disable events
         STEAM_ENABLE_DYNAMIC_BACKLIGHT = "1";
+
+        # Enabled fan control toggle in steam
+        STEAM_ENABLE_FAN_CONTROL = "1";
 
         # Let's try this across the board to see if it breaks anything
         # Helps performance in HZD, Cyberpunk, at least

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -161,6 +161,14 @@ let
     export GAMESCOPE_MODE_SAVE_FILE="$gamescope_config_dir/modes.cfg"
     touch "$GAMESCOPE_MODE_SAVE_FILE"
 
+    # Ensure we don't strand users without a "joshcolor" kernel while
+    # color management is in beta from the vendor.
+    # https://github.com/Jovian-Experiments/Jovian-NixOS/issues/91
+    colorManagementHack=""
+    if [[ $(uname -r) =~ 6\.1\.[0-9]+-valve[0-9]+ ]]; then
+      colorManagementHack="--disable-color-management"
+    fi
+
     gamescope_incantation=(
       "${gamescope-shim}"
 
@@ -186,6 +194,8 @@ let
       #               -> adwaita or similar
       --cursor ${steamdeck-hw-theme}/share/steamos/steamos-cursor.png
       --cursor-hotspot 5,3
+
+      $colorManagementHack
 
       # TODO[Jovian]: only add when running steam
       --steam

--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -116,6 +116,10 @@ let
     # TODO[Jovian]: Explore other ways to stop the session?
     #               -> `systemctl --user stop steam-session.slice`?
 
+    # Plop GAMESCOPE_MODE_SAVE_FILE into $XDG_CONFIG_HOME (defaults to ~/.config).
+    export GAMESCOPE_MODE_SAVE_FILE="''${XDG_CONFIG_HOME:-$HOME/.config}/gamescope/modes.cfg"
+    export GAMESCOPE_PATCHED_EDID_FILE="''${XDG_CONFIG_HOME:-$HOME/.config}/gamescope/edid.bin"
+
     exec ${config.security.wrapperDir}/gamescope "$@"
   '';
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -19,6 +19,10 @@ rec {
     ];
   };
 
+  gamescope = final.callPackage ./pkgs/gamescope {
+    gamescope' = super.gamescope;
+  };
+
   mangohud = final.callPackage ./pkgs/mangohud {
     libXNVCtrl = linuxPackages_jovian.nvidia_x11.settings.libXNVCtrl;
     mangohud32 = final.pkgsi686Linux.mangohud;

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -2,6 +2,7 @@
 , fetchpatch
 , fetchFromGitHub
 , glm
+, gbenchmark
 }:
 
 # NOTE: vendoring gamescope for the time being since we want to match the
@@ -9,8 +10,8 @@
 #       version coherent with the version as shipped by the vendor.
 
 let
-  version = "3.12.0-beta2";
-  hash = "sha256-EVR9MOwbwVxe278LOtfAZxq39E2J+3CIvxIkH535Oi0=";
+  version = "3.12.0-beta5";
+  hash = "sha256-KN4WsXrZSps6UQMKsqOV35mwFaJMHitaAlNYKW8Snm8=";
 in
 gamescope'.overrideAttrs({ buildInputs, ... }: {
   name = "gamescope-${version}";
@@ -30,6 +31,7 @@ gamescope'.overrideAttrs({ buildInputs, ... }: {
   ];
 
   buildInputs = buildInputs ++ [
+    gbenchmark
     glm
   ];
 })

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -1,0 +1,35 @@
+{ gamescope'
+, fetchpatch
+, fetchFromGitHub
+, glm
+}:
+
+# NOTE: vendoring gamescope for the time being since we want to match the
+#       version shipped by the vendor, which does not work without the kernel
+#       version coherent with the version as shipped by the vendor.
+
+let
+  version = "3.12.0-beta2";
+  hash = "sha256-EVR9MOwbwVxe278LOtfAZxq39E2J+3CIvxIkH535Oi0=";
+in
+gamescope'.overrideAttrs({ buildInputs, ... }: {
+  name = "gamescope-${version}";
+  src = fetchFromGitHub {
+    owner = "ValveSoftware";
+    repo = "gamescope";
+    rev = "refs/tags/${version}";
+    inherit hash;
+  };
+
+  # (We are purposefully clobbering the patches from Nixpkgs here)
+  patches = [
+    (fetchpatch {
+      url = "https://raw.githubusercontent.com/NixOS/nixpkgs/770f6182ac3084eb9ed836e1f34fce0595c905db/pkgs/applications/window-managers/gamescope/use-pkgconfig.patch";
+      sha256 = "sha256-BqP20qoVH47xT/Pn4P9V5wUvHK/AJivam0Xenr8AbGk=";
+    })
+  ];
+
+  buildInputs = buildInputs ++ [
+    glm
+  ];
+})

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -10,8 +10,8 @@
 #       version coherent with the version as shipped by the vendor.
 
 let
-  version = "3.12.0-beta5";
-  hash = "sha256-KN4WsXrZSps6UQMKsqOV35mwFaJMHitaAlNYKW8Snm8=";
+  version = "3.12.0-beta8";
+  hash = "sha256-/9NGlM1FaDfdFkyIjbbJ39GB5JkkIFeZXQwtCvFUuX4=";
 in
 gamescope'.overrideAttrs({ buildInputs, ... }: {
   name = "gamescope-${version}";

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -6,8 +6,7 @@
 }:
 
 # NOTE: vendoring gamescope for the time being since we want to match the
-#       version shipped by the vendor, which does not work without the kernel
-#       version coherent with the version as shipped by the vendor.
+#       version shipped by the vendor, ensuring feature level is equivalent.
 
 let
   version = "3.12.0-beta8";

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,7 +9,7 @@ let
   ;
 
   kernelVersion = "6.1.21";
-  vendorVersion = "valve1";
+  vendorVersion = "joshcolor1";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -109,6 +109,6 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-ypYhz1kD+enIl31yhjlzqDnd3RqQcyc+7Udlw1Y5iSM=";
+    hash = "sha256-TlHJcYClenMHBNsS+HiHmTfS3JZpHJ00AdroCFzrDhc=";
   };
 } // (args.argsOverride or { }))

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -109,6 +109,19 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-TlHJcYClenMHBNsS+HiHmTfS3JZpHJ00AdroCFzrDhc=";
+    hash = "sha256-nwog+yXv9v1vENLELwJrtizRv2w7PVWivc+NvAL+Gn0=";
+
+    # Sometimes the vendor doesn't update the EXTRAVERSION tag.
+    # Let's fix it up in post.
+    # ¯\_(ツ)_/¯
+    # Also, `postPatch` on the kernel doesn't compose in `buildLinux`.
+    # ¯\_(ツ)_/¯
+    postFetch = ''
+      (
+      echo ":: Fixing-up EXTRAVERSION with actual tag"
+      cd $out
+      sed -i -e 's/^EXTRAVERSION =.*/EXTRAVERSION = -${vendorVersion}/g' Makefile
+      )
+    '';
   };
 } // (args.argsOverride or { }))

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,7 +9,7 @@ let
   ;
 
   kernelVersion = "6.1.21";
-  vendorVersion = "joshcolor1";
+  vendorVersion = "joshcolor2";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -109,7 +109,7 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-nwog+yXv9v1vENLELwJrtizRv2w7PVWivc+NvAL+Gn0=";
+    hash = "sha256-rA27qy23zMsBQxL/m+qyt8C7opTWnnQOqD7Bzkc3G1w=";
 
     # Sometimes the vendor doesn't update the EXTRAVERSION tag.
     # Let's fix it up in post.

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -9,7 +9,7 @@ let
   ;
 
   kernelVersion = "6.1.21";
-  vendorVersion = "joshcolor2";
+  vendorVersion = "saml";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -109,7 +109,7 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-rA27qy23zMsBQxL/m+qyt8C7opTWnnQOqD7Bzkc3G1w=";
+    hash = "sha256-S3McbOkG9OANehr3xO0wxXGlSR1NyAtgtRIQKbq6k4M=";
 
     # Sometimes the vendor doesn't update the EXTRAVERSION tag.
     # Let's fix it up in post.


### PR DESCRIPTION
This updates the kernel and gamescope to the version used in ~~20230426.1000~~ 20230516.1000.

The update needs to happen together, or things don't work exactly well. It also requires adding the new color feature for complete support.

Note that I personally am using it paired with #78.

* * *

#### What was done

 - Launched steam through a systemd unit, verified that saturation knob works.
 - Verified that logs (journalctl) aren't spewing loads of crap
 - :new: Verified colours are fine (not weirdly dark) in desktop mode
 - :new: Verified "night mode" (steam's redshift) now works fine again
 - :new: Verified gamescope+steam works with these changes on mainline (6.3)
 - :new: Verified state of the "current" (previous) vendor kernel version...

#### Known problems (unsolvable)

~~Users updating to this state, but who will not reboot, will be stranded without the gamescope interface when/if it is restarted.~~

~~We *could* attempt to sniff at the kernel, and when it is lower than `6.1.21-valve1` *do something* at runtime, but what exactly is hard to decide. We can't rely on gamescope to run something to notify the user!~~

I forgot about `--disable-color-management`. With `--disable-color-management` things are now correct.

We can check for `6.1.*-valve*` and tack on `--disable-color-management` for now. We don't have to do anything fancy for mainline 6.3.

NOTE: I tested this by making this local change with `git checkout jovian/development -- ./pkgs/linux-jovian/`.

Verifying this applies correctly can be done with `pgrep -fla /run/wrappers/bin/gamescope`.