### PR TITLE
mesa-radv-jupiter: steamos-3.5.1 -> radv-23.6.0

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -29,7 +29,11 @@ rec {
     inherit (final.python3Packages) mako;
   };
 
-  mesa-radv-jupiter = final.callPackage ./pkgs/mesa-radv-jupiter { };
+  mesa-radv-jupiter = final.callPackage ./pkgs/mesa-radv-jupiter {
+    # Compat with the inputs from Nixpkgs; those are for Darwin.
+    OpenGL = null;
+    Xplugin = null;
+  };
 
   jupiter-fan-control = final.callPackage ./pkgs/jupiter-fan-control { };
 

--- a/pkgs/mesa-radv-jupiter/default.nix
+++ b/pkgs/mesa-radv-jupiter/default.nix
@@ -384,7 +384,7 @@ self = stdenv.mkDerivation {
   };
 
   meta = with lib; {
-    description = "An open source 3D graphics library";
+    description = "An open source 3D graphics library (RADV only)";
     longDescription = ''
       The Mesa project began as an open-source implementation of the OpenGL
       specification - a system for rendering interactive 3D graphics. Over the

--- a/pkgs/mesa-radv-jupiter/disk_cache-include-dri-driver-path-in-cache-key.patch
+++ b/pkgs/mesa-radv-jupiter/disk_cache-include-dri-driver-path-in-cache-key.patch
@@ -10,16 +10,18 @@ diff --git a/meson_options.txt b/meson_options.txt
 index b8f753e2e1a..70d9071c8be 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -452,6 +452,12 @@ option(
+@@ -452,7 +452,14 @@ option(
    value : true,
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )
+ 
 +option(
 +  'disk-cache-key',
 +  type : 'string',
 +  value : '',
 +  description : 'Mesa cache key.'
 +)
++
  option('egl-lib-suffix',
    type : 'string',
    value : '',


### PR DESCRIPTION
This also syncs our derivation with Nixpkgs.

I tried keeping it as much as possible as-is, but it required some finesse... To solve those issues I preferred commenting so that diffing the next update is easier.

We *could* instead pass args in the overlay.