### PR TITLE
modules: Add decky-loader

### DIFF
--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -39,6 +39,15 @@ in
           '';
         };
 
+        extraPythonPackages = mkOption {
+          type = types.functionTo (types.listOf types.package);
+          example = lib.literalExpression "pythonPackages: with pythonPackages; [ hid ]";
+          default = pythonPackages: with pythonPackages; [];
+          description = ''
+            Extra Python packages to add to the PYTHONPATH of the loader.
+          '';
+        };
+
         stateDir = mkOption {
           type = types.path;
           default = "/var/lib/decky-loader";
@@ -78,10 +87,13 @@ in
 
         wantedBy = [ "multi-user.target" ];
 
-        environment = {
+        environment = let
+          inherit (cfg.package.passthru) python;
+        in {
           UNPRIVILEGED_USER = cfg.user;
           UNPRIVILEGED_PATH = cfg.stateDir;
           PLUGIN_PATH = "${cfg.stateDir}/plugins";
+          PYTHONPATH = "${python.withPackages cfg.extraPythonPackages}/${python.sitePackages}";
         };
 
         path = with pkgs; [ coreutils gawk ] ++ cfg.extraPackages;

--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -22,6 +22,14 @@ in
           '';
         };
 
+        package = mkOption {
+          type = types.package;
+          default = pkgs.decky-loader;
+          description = ''
+            The loader package to use.
+          '';
+        };
+
         extraPackages = mkOption {
           type = types.listOf types.package;
           example = lib.literalExpression "[ pkgs.curl pkgs.unzip ]";
@@ -84,7 +92,7 @@ in
         '';
 
         serviceConfig = {
-          ExecStart = "${pkgs.decky-loader}/bin/decky-loader";
+          ExecStart = "${cfg.package}/bin/decky-loader";
           KillSignal = "SIGINT";
         };
       };

--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -17,7 +17,7 @@ in
         enable = mkOption {
           type = types.bool;
           default = false;
-          description = ''
+          description = lib.mdDoc ''
             Whether to enable the Steam Deck Plugin Loader.
           '';
         };
@@ -25,7 +25,8 @@ in
         package = mkOption {
           type = types.package;
           default = pkgs.decky-loader;
-          description = ''
+          defaultText = lib.literalExpression "pkgs.decky-loader";
+          description = lib.mdDoc ''
             The loader package to use.
           '';
         };
@@ -34,7 +35,7 @@ in
           type = types.listOf types.package;
           example = lib.literalExpression "[ pkgs.curl pkgs.unzip ]";
           default = [];
-          description = ''
+          description = lib.mdDoc ''
             Extra packages to add to the service PATH.
           '';
         };
@@ -43,7 +44,8 @@ in
           type = types.functionTo (types.listOf types.package);
           example = lib.literalExpression "pythonPackages: with pythonPackages; [ hid ]";
           default = pythonPackages: with pythonPackages; [];
-          description = ''
+          defaultText = lib.literalExpression "pythonPackages: with pythonPackages; []";
+          description = lib.mdDoc ''
             Extra Python packages to add to the PYTHONPATH of the loader.
           '';
         };
@@ -51,7 +53,7 @@ in
         stateDir = mkOption {
           type = types.path;
           default = "/var/lib/decky-loader";
-          description = ''
+          description = lib.mdDoc ''
             Directory to store plugins and data.
           '';
         };
@@ -59,7 +61,7 @@ in
         user = mkOption {
           type = types.str;
           default = "decky";
-          description = ''
+          description = lib.mdDoc ''
             The user Decky Loader should run plugins as.
           '';
         };

--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -1,0 +1,93 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkDefault
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.jovian.decky-loader;
+in
+{
+  options = {
+    jovian = {
+      decky-loader = {
+        enable = mkOption {
+          type = types.bool;
+          default = false;
+          description = ''
+            Whether to enable the Steam Deck Plugin Loader.
+          '';
+        };
+
+        extraPackages = mkOption {
+          type = types.listOf types.package;
+          example = lib.literalExpression "[ pkgs.curl pkgs.unzip ]";
+          default = [];
+          description = ''
+            Extra packages to add to the service PATH.
+          '';
+        };
+
+        stateDir = mkOption {
+          type = types.path;
+          default = "/var/lib/decky-loader";
+          description = ''
+            Directory to store plugins and data.
+          '';
+        };
+
+        user = mkOption {
+          type = types.str;
+          default = "decky";
+          description = ''
+            The user Decky Loader should run plugins as.
+          '';
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable (lib.mkMerge [
+    (lib.mkIf (cfg.user == "decky") {
+      users.users.decky = {
+        group = "decky";
+        home = cfg.stateDir;
+        isSystemUser = true;
+      };
+      users.groups.decky = {};
+    })
+    {
+      # As of 2023/07/16, the Decky Loader needs to run as root, even if you never
+      # use plugins that require it. It setuid's to the unprivileged user to
+      # run plugins. Running as non-root is unsupported and currently breaks:
+      #
+      # <https://github.com/SteamDeckHomebrew/decky-loader/issues/446#issuecomment-1637177368>
+      systemd.services.decky-loader = {
+        description = "Steam Deck Plugin Loader";
+
+        wantedBy = [ "multi-user.target" ];
+
+        environment = {
+          UNPRIVILEGED_USER = cfg.user;
+          UNPRIVILEGED_PATH = cfg.stateDir;
+          PLUGIN_PATH = "${cfg.stateDir}/plugins";
+        };
+
+        path = with pkgs; [ coreutils gawk ] ++ cfg.extraPackages;
+
+        preStart = ''
+          mkdir -p "${cfg.stateDir}"
+          chown -R "${cfg.user}:" "${cfg.stateDir}"
+        '';
+
+        serviceConfig = {
+          ExecStart = "${pkgs.decky-loader}/bin/decky-loader";
+          KillSignal = "SIGINT";
+        };
+      };
+    }
+  ]);
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./decky-loader.nix
     ./steamdeck/default.nix
     ./overlay.nix
     ./steam/default.nix

--- a/overlay.nix
+++ b/overlay.nix
@@ -60,4 +60,6 @@ rec {
   });
 
   sdgyrodsu = final.callPackage ./pkgs/sdgyrodsu { };
+
+  decky-loader = final.callPackage ./pkgs/decky-loader { };
 }

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -102,6 +102,7 @@ let
 
       mkdir -p $out/lib
       cp -r backend $out/lib/decky-loader
+      cp -r plugin $out/lib/decky-loader/
 
       ln -s ${frontend} $out/lib/decky-loader/static
 

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -86,6 +86,8 @@ let
     aiohttp-cors
     watchdog
     certifi
+
+    click # shotty
   ]);
 
   loader = stdenv.mkDerivation {

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -121,6 +121,7 @@ let
 
     passthru = {
       inherit frontendDeps;
+      python = python3;
     };
 
     meta = with lib; {

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -6,8 +6,8 @@
 , python3
 }:
 let
-  version = "2.10.3";
-  hash = "sha256-cgLnej/mO8ShzUBevGBF+a78VhQhudDvpmdwgRZ4Wm8=";
+  version = "2.10.4";
+  hash = "sha256-uLERXUfAo45kWP4Q4RPiHJaFXlfxmlXA5LoRv/kTItI=";
   npmHash = "sha256-FyrFVHRCJX/PUGilLpiRaQwcDUO9edNWCvN/3ugVejQ=";
 
   src = fetchFromGitHub {

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -1,0 +1,130 @@
+{ lib
+, stdenv
+, fetchFromGitHub
+, nodePackages
+, nodejs
+, python3
+}:
+let
+  version = "2.10.3";
+  hash = "sha256-cgLnej/mO8ShzUBevGBF+a78VhQhudDvpmdwgRZ4Wm8=";
+  npmHash = "sha256-FyrFVHRCJX/PUGilLpiRaQwcDUO9edNWCvN/3ugVejQ=";
+
+  src = fetchFromGitHub {
+    owner = "SteamDeckHomebrew";
+    repo = "decky-loader";
+    rev = "v${version}";
+    inherit hash;
+  };
+
+  frontendDeps = stdenv.mkDerivation {
+    name = "decky-loader-frontend-deps-${version}.tar.gz";
+    inherit src;
+
+    nativeBuildInputs = [ nodePackages.pnpm ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      export SOURCE_DATE_EPOCH=1
+      cd frontend
+      pnpm i --ignore-scripts --ignore-pnpmfile --frozen-lockfile --node-linker=hoisted
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      rm node_modules/.modules.yaml
+      tar -czf $out --owner=0 --group=0 --numeric-owner --format=gnu \
+        --mtime="@$SOURCE_DATE_EPOCH" --sort=name \
+        node_modules
+
+      runHook postInstall
+    '';
+
+    outputHashMode = "flat";
+    outputHashAlgo = "sha256";
+    outputHash = npmHash;
+  };
+
+  frontend = stdenv.mkDerivation {
+    pname = "decky-loader-frontend";
+    inherit version src;
+
+    nativeBuildInputs = [ nodejs nodePackages.pnpm ];
+
+    dontConfigure = true;
+
+    buildPhase = ''
+      runHook preBuild
+
+      pushd frontend
+      tar xf ${frontendDeps}
+      patchShebangs --build node_modules
+      pnpm build
+      popd
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      cp -r backend/static $out
+
+      runHook postInstall
+    '';
+  };
+
+  pythonEnv = python3.withPackages (py: with py; [
+    aiohttp
+    aiohttp-jinja2
+    aiohttp-cors
+    watchdog
+    certifi
+  ]);
+
+  loader = stdenv.mkDerivation {
+    pname = "decky-loader";
+    inherit version src;
+
+    buildInputs = [ pythonEnv ];
+
+    dontConfigure = true;
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/lib
+      cp -r backend $out/lib/decky-loader
+
+      ln -s ${frontend} $out/lib/decky-loader/static
+
+      mkdir $out/bin
+      cat << EOF >$out/bin/decky-loader
+      #!/bin/sh
+      export PATH=${pythonEnv}/bin:$PATH
+      exec ${pythonEnv}/bin/python3 $out/lib/decky-loader/main.py
+      EOF
+      chmod +x $out/bin/decky-loader
+
+      runHook postInstall
+    '';
+
+    passthru = {
+      inherit frontendDeps;
+    };
+
+    meta = with lib; {
+      description = "A plugin loader for the Steam Deck";
+      homepage = "https://github.com/SteamDeckHomebrew/decky-loader";
+      platforms = platforms.linux;
+      license = licenses.gpl2Only;
+    };
+  };
+in loader

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -1,6 +1,7 @@
 { lib
 , stdenv
 , fetchFromGitHub
+, fetchpatch
 , nodePackages
 , nodejs
 , python3
@@ -94,6 +95,19 @@ let
     pname = "decky-loader";
     inherit version src;
 
+    patches = [
+      # Patches submitted upstream: https://github.com/SteamDeckHomebrew/decky-loader/pull/528
+      # FIXME: remove when merged
+      (fetchpatch {
+        url = "https://github.com/SteamDeckHomebrew/decky-loader/commit/e3a8de2490fea942edad4c0a8971a3958cc01d9b.patch";
+        hash = "sha256-0klVKBvywCXfak8rdB3k4sK/eN/fcY42C29+J1W4pOM=";
+      })
+      (fetchpatch {
+        url = "https://github.com/SteamDeckHomebrew/decky-loader/commit/89f37f4f547ff0d78783899df80a046bc864c48e.patch";
+        hash = "sha256-9+shHrOJntHrqFbdsuBMD5GCQSx7DH3L1FLJihW9xCg=";
+      })
+    ];
+
     buildInputs = [ pythonEnv ];
 
     dontConfigure = true;
@@ -112,6 +126,7 @@ let
       cat << EOF >$out/bin/decky-loader
       #!/bin/sh
       export PATH=${pythonEnv}/bin:$PATH
+      export DECKY_VERSION=v${version}
       exec ${pythonEnv}/bin/python3 $out/lib/decky-loader/main.py
       EOF
       chmod +x $out/bin/decky-loader


### PR DESCRIPTION
This PR adds integration of [Decky Loader](https://github.com/SteamDeckHomebrew/decky-loader).

The loader itself runs as root and setuid's to an unprivileged user to run plugins. Running as non-root is [unsupported](https://github.com/SteamDeckHomebrew/decky-loader/issues/446#issuecomment-1637177368) and currently breaks plugin installation.