### PR TITLE
jupiter-dock-updater-bin: 20221026.01 -> 20230714.01

### DIFF
--- a/pkgs/jupiter-dock-updater-bin/default.nix
+++ b/pkgs/jupiter-dock-updater-bin/default.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-dock-updater-bin";
-  version = "20221026.01";
+  version = "20230714.01";
 
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "jupiter-dock-updater-bin";
     rev = "jupiter-${version}";
-    hash = "sha256-Iu9oAy9wVIMowD+wOABIbLjA0Vgr7xndlz0/jhuDuVg=";
+    hash = "sha256-tfMPBC1x4YE3Sv3GbVkQJ12CYODeHjK1cBEaw9jBZpY=";
   };
 
   buildInputs = [


### PR DESCRIPTION
No useful changelog.

* * *

### What was done

 - Updated the dock, it still works

### Untested

DP/HDMI output, especially with MST.