### PR TITLE
linux-jovian: 6.1.29-valve4 -> 6.1.39-valve1

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -37,15 +37,6 @@ buildLinux (args // rec {
     DRM_AMDGPU_SI = lib.mkForce no;
     DRM_RADEON = no;
 
-    # Jovian-NixOS: nah, let's use NixOS defaults here.
-    # #
-    # # Use xz instead of zstd to save space
-    # #
-    # KERNEL_XZ = yes;
-    # KERNEL_ZSTD = no;
-    # MODULE_COMPRESS_XZ = yes;
-    # MODULE_COMPRESS_ZSTD = no;
-
     # Doesn't build on latest tag, not used in neptune hardware (?)
     SND_SOC_CS35L36 = no;
     # Update this to =y to workaround initialization issues and deadlocks when loaded as module
@@ -72,6 +63,9 @@ buildLinux (args // rec {
     EXTCON_STEAMDECK = module;
     LEDS_STEAMDECK = module;
     SENSORS_STEAMDECK = module;
+
+    # Enable support for AMDGPU color calibration features
+    DRM_AMD_COLOR_STEAMDECK = yes;
 
     # PARAVIRT options have overhead, even on bare metal boots. They can cause
     # spinlocks to not be inlined as well. Either way, we don't intend to run this

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -8,8 +8,8 @@ let
     versions
   ;
 
-  kernelVersion = "6.1.29";
-  vendorVersion = "valve4";
+  kernelVersion = "6.1.39";
+  vendorVersion = "valve1";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -112,7 +112,7 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-a2OxAfbv9idLhklpIeswGtBXPkk1sn/q/fdYB49RLOc=";
+    hash = "sha256-IXErs8AzcxDLU5qan7exyN6jc4yUxtjbHYRLmlJwup0=";
 
     # Sometimes the vendor doesn't update the EXTRAVERSION tag.
     # Let's fix it up in post.


### PR DESCRIPTION
(No useful changelog due to the stable bump.)

* * *

### What was done

 - Booted system seems to work just as it did beforehand