### PR TITLE
jupiter-hw-support: 20230623.1 -> 20230728.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20230623.1";
+  version = "20230728.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  hash = "sha256-40xx9NFFIQ2KNVPELrDzQU4cGUzaTzCub/NTd/DKoxs=";
+  hash = "sha256-hDxW9q2vqvCuPq82EyESdy+2xzPw+i7kx7uJ3UzlYbg=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
 - https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20230623.1...jupiter-20230728.1

* * *

### What was done

 - Updated the controller firmware (and after the bump, tried to, been told it's already updated)