### PR TITLE
steam-jupiter: 1.0.0.74-2.19 -> 1.0.0.75-1.4

### DIFF
--- a/pkgs/steam-jupiter/unwrapped.nix
+++ b/pkgs/steam-jupiter/unwrapped.nix
@@ -7,8 +7,8 @@
 
 let
   bundle = fetchurl {
-    url = "https://steamdeck-packages.steamos.cloud/archlinux-mirror/sources/jupiter-main/steam-jupiter-stable-1.0.0.74-2.19.src.tar.gz";
-    sha256 = "sha256-jY5gPTHQ8oLg2nqd2yNQWjVGuX4fl7uMPCpphJV4EH0=";
+    url = "https://steamdeck-packages.steamos.cloud/archlinux-mirror/sources/jupiter-main/steam-jupiter-stable-1.0.0.75-1.4.src.tar.gz";
+    sha256 = "sha256-X25OKVF5VZI936nJ7ExQqX/XximJE2cUvK2A+zkrBuk=";
   };
 
 in steam-original.overrideAttrs (old: {


### PR DESCRIPTION
This aims at reducing the diff between us and the vendor on main, see #118.

 - https://github.com/Jovian-Experiments/PKGBUILDs-mirror/compare/jupiter-main/steam-jupiter-stable-1.0.0.74-2.19...jupiter-main/steam-jupiter-stable-1.0.0.75-1.4

* * *

#141 solves the previous reason for drafting; this is the only difference of note, handling OOBE.