### PR TITLE
Revert "modules/steam: Add workaround for color management and vendor kernels"

### DIFF
--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -161,14 +161,6 @@ let
     export GAMESCOPE_MODE_SAVE_FILE="$gamescope_config_dir/modes.cfg"
     touch "$GAMESCOPE_MODE_SAVE_FILE"
 
-    # Ensure we don't strand users without a "joshcolor" kernel while
-    # color management is in beta from the vendor.
-    # https://github.com/Jovian-Experiments/Jovian-NixOS/issues/91
-    colorManagementHack=""
-    if [[ $(uname -r) =~ 6\.1\.[0-9]+-valve[0-9]+ ]]; then
-      colorManagementHack="--disable-color-management"
-    fi
-
     gamescope_incantation=(
       "${gamescope-shim}"
 
@@ -194,8 +186,6 @@ let
       #               -> adwaita or similar
       --cursor ${steamdeck-hw-theme}/share/steamos/steamos-cursor.png
       --cursor-hotspot 5,3
-
-      $colorManagementHack
 
       # TODO[Jovian]: only add when running steam
       --steam


### PR DESCRIPTION
This reverts commit 73c4e25ced14d11eed7e2196b34acff936ae3692.

* * *

Fixes #91.

Thank you @pongo1231 for noticing!

I was wondering why color stuff was broken... and assumed I was holding it wrong, but didn't know why.