### PR TITLE
steamdeck/hw-support: Loosen (optionally) product_serial access

### DIFF
--- a/modules/steamdeck/hw-support.nix
+++ b/modules/steamdeck/hw-support.nix
@@ -27,6 +27,15 @@ in
         default = cfg.enable;
         type = types.bool;
       };
+      enableProductSerialAccess = mkOption {
+        default = cfg.enable;
+        type = types.bool;
+        description = lib.mdDoc ''
+          > Loosen the product_serial node to `440 / root:wheel`, rather than `400 / root:root`
+          > to allow the physical users to read S/N without auth.
+          — holo-dmi-rules 1.0
+        '';
+      };
     };
   };
 
@@ -34,6 +43,11 @@ in
     (mkIf (cfg.enable) {
       # Firmware is required in stage-1 for early KMS.
       hardware.enableRedistributableFirmware = true;
+    })
+    (mkIf (cfg.enableProductSerialAccess) {
+      systemd.tmpfiles.rules = [
+        "z /sys/class/dmi/id/product_serial 440 root wheel - -"
+      ];
     })
     (mkIf (cfg.enableDefaultStage1Modules) {
       boot.initrd.kernelModules = [


### PR DESCRIPTION
For #118, handles the equivalent of `holo-dmi-rules`.

* * *

*shrugs*

 - https://github.com/Jovian-Experiments/steamos-customizations-jupiter/blob/b72ca45767283c45e5d81792834a4069a85718b4/misc/bin/steamos-dump-info.in#L38

Looks like vendor's implementation is incomplete for at least this vendor script.

* * *

I think that it actually was meant for `steamos-devkit-service`. Which uses it to reply to "identify" requests.