### PR TITLE
jupiter-hw-support: 20230728.1 -> 20230810.2

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20230728.1";
+  version = "20230810.2";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  hash = "sha256-hDxW9q2vqvCuPq82EyESdy+2xzPw+i7kx7uJ3UzlYbg=";
+  hash = "sha256-/xlrMXcQT/l1qj40EUD1LlCT4iQ4okypxPh4S6zztTY=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
 - https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20230728.1...jupiter-20230810.2

Tested by running the update script.

Tested again by running the update script.