### PR TITLE
modules/steam: Fail better when `jovian.steam.user` is not provided.

### DIFF
--- a/modules/steam.nix
+++ b/modules/steam.nix
@@ -279,8 +279,7 @@ in
         };
 
         user = mkOption {
-          type = types.nullOr types.str;
-          default = null;
+          type = types.str;
           description = lib.mdDoc ''
             The user to run Steam with.
           '';


### PR DESCRIPTION
Fixes #135