### PR TITLE
support/test-iso: Init expressions to build a test ISO

### DIFF
--- a/support/test-iso/README.md
+++ b/support/test-iso/README.md
@@ -1,0 +1,4 @@
+Jovian NixOS Test ISO
+=====================
+
+> **NOTE**: This is not for installing. This is not for daily driving. This is a development aid to start from a fresh new environment for OOBE issues.

--- a/support/test-iso/configuration.nix
+++ b/support/test-iso/configuration.nix
@@ -1,0 +1,25 @@
+{ config, pkgs, modulesPath, ... }:
+
+{
+  imports = [
+    (modulesPath + "/installer/cd-dvd/iso-image.nix")
+    (modulesPath + "/profiles/all-hardware.nix")
+    ./jovian.nix
+    ./tty.nix
+    ./user.nix
+  ];
+
+  config = {
+    isoImage.isoBaseName = "Jovian-NixOS-FOR-TESTING-ONLY";
+    isoImage.makeEfiBootable = true;
+    isoImage.makeUsbBootable = true;
+    isoImage.squashfsCompression = "zstd -Xcompression-level 15";
+    isoImage.isoName = "${config.isoImage.isoBaseName}-${config.system.nixos.label}-${pkgs.stdenv.hostPlatform.system}.iso";
+
+    hardware.enableRedistributableFirmware = true;
+    nixpkgs.config.allowUnfree = true;
+
+    # NOTE: this is an insecure system, but it's also FOR TESTING ONLY.
+    services.openssh.enable = true;
+  };
+}

--- a/support/test-iso/default.nix
+++ b/support/test-iso/default.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+
+let
+  nixos = import "${pkgs.path}/nixos";
+  eval = nixos {
+    configuration = {
+      imports = [
+        ./configuration.nix
+      ];
+    };
+  };
+in
+with eval;
+config.system.build.isoImage

--- a/support/test-iso/jovian.nix
+++ b/support/test-iso/jovian.nix
@@ -1,0 +1,17 @@
+{
+  imports = [
+    ../../modules
+  ];
+
+  jovian = {
+    devices.steamdeck = {
+      enable = true;
+    };
+    steam = {
+      enable = true;
+      autoStart = true;
+      user = "deck";
+    };
+  };
+  networking.networkmanager.enable = true;
+}

--- a/support/test-iso/tty.nix
+++ b/support/test-iso/tty.nix
@@ -1,0 +1,5 @@
+{ config, lib, pkgs, ... }:
+
+{
+  services.getty.autologinUser = config.jovian.steam.user;
+}

--- a/support/test-iso/user.nix
+++ b/support/test-iso/user.nix
@@ -1,0 +1,21 @@
+{ config, pkgs, ... }:
+
+{
+  users.users = {
+    "${config.jovian.steam.user}" = {
+      isNormalUser = true;
+      uid = 1000;
+      extraGroups = [
+        "audio"
+        "networkmanager"
+        "video"
+        "wheel"
+      ];
+      initialHashedPassword = "TEST_PASSWORD_DO_NOT_USE";
+    };
+    root = {
+      initialHashedPassword = "TEST_PASSWORD_DO_NOT_USE";
+    };
+  };
+  security.sudo.wheelNeedsPassword = false;
+}


### PR DESCRIPTION
This is mainly used to test bootstrapping/"OOBE".