### PR TITLE
jupiter-hw-support: 20230908.1 -> 20230918.1

### DIFF
--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,13 +1,13 @@
 { fetchFromGitHub }:
 
 let
-  version = "20230908.1";
+  version = "20230918.1";
 in (fetchFromGitHub {
   name = "jupiter-hw-support-${version}";
   owner = "Jovian-Experiments";
   repo = "jupiter-hw-support";
   rev = "jupiter-${version}";
-  hash = "sha256-3VCvZUxqOiCc/ZqJmPrz+YAvRwZ58I6V+Jwej7kK4bY=";
+  hash = "sha256-w5rX8h/P4gCYV6WVj9XhyVrg1VUQ+z+ev8ijiPgl0u0=";
 }) // {
   inherit version;
 }


### PR DESCRIPTION
 - https://github.com/Jovian-Experiments/jupiter-hw-support/compare/jupiter-20230908.1...jupiter-20230918.1

* * *

### What was done

 - Booted with new bios version after updating it with fwupd.