### PR TITLE
steamdeck/firmware: add jupiter firmware to hardware.firmware instead of another overlay

### DIFF
--- a/modules/steamdeck/firmware.nix
+++ b/modules/steamdeck/firmware.nix
@@ -35,9 +35,7 @@ in
 
   config = mkMerge [
     (mkIf (cfg.enable) {
-      nixpkgs.overlays = [
-        (_: prev: { linux-firmware = prev.linux-firmware-jupiter; })
-      ];
+      hardware.firmware = [(lib.hiPrio pkgs.linux-firmware-jupiter)];
     })
     (mkIf (cfg.autoUpdate) {
       systemd.packages = [pkgs.steamdeck-firmware];


### PR DESCRIPTION
Overlays are unfortunately weirdly order dependent