### PR TITLE
steamdeck/sound: change how we make vendor config preferred

### DIFF
--- a/modules/steamdeck/sound.nix
+++ b/modules/steamdeck/sound.nix
@@ -7,8 +7,10 @@ let
     cp -r --no-preserve=all ${pkgs.alsa-ucm-conf} $out
 
     # override acp5x configs with Jovian stuff
-    # NOTE: different location to account for upstream changes in alsa-ucm-conf 1.2.9+
-    cp -rf ${pkgs.jupiter-hw-support}/share/alsa/ucm2/conf.d/acp5x/* $out/share/alsa/ucm2/AMD/acp5x/
+    cp -rf ${pkgs.jupiter-hw-support}/share/alsa $out/share/alsa
+    
+    # remove more specific upstream symlink so Valve acp5x config is picked
+    rm $out/share/alsa/ucm2/conf.d/acp5x/Valve-Jupiter-1.conf
   '';
 in
 {


### PR DESCRIPTION
This doesn't actually matter but it costs us nothing and brings us closer to vendor so why not.