### PR TITLE
Makes `jovian.steam.desktopSession` tell you which session names are valid

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -31,7 +31,15 @@ in
         };
 
         desktopSession = mkOption {
-          type = types.nullOr types.str;
+          type = with types ; nullOr str // {         
+            check = userProvidedDesktopSession:
+              lib.assertMsg (userProvidedDesktopSession != null -> (str.check userProvidedDesktopSession && lib.elem userProvidedDesktopSession config.services.xserver.displayManager.sessionData.sessionNames)) ''
+                  Desktop session '${userProvidedDesktopSession}' not found.
+                  Valid values for 'jovian.steam.desktopSession' are:
+                    ${lib.concatStringsSep "\n  " (lib.lists.remove "gamescope-wayland" config.services.xserver.displayManager.sessionData.sessionNames)}
+                  If you don't want a desktop session to switch to, remove 'jovian.steam.desktopSession' from your config.
+              '';
+          };
           default = null;
           example = "plasma";
           description = lib.mdDoc ''


### PR DESCRIPTION
Solves #163.

Just checks against `config.services.xserver.displayManager.sessionData.sessionNames` and displays those names when an invalid name is displayed. 

I also removed it displaying `gamescope-wayland`, since that should be accessed by not setting the config at all, and letting it be the default. 

It's largely just the same code here: https://github.com/NixOS/nixpkgs/blob/f78122df472e2871b2623b82b8c38a3e9f2807ea/nixos/modules/services/x11/display-managers/default.nix#L297-L305, but I changed some things to make it more readable (to me). 

This is my first nix PR/MR anywhere, so there might be some sloppy stuff that I didn't catch. 