### PR TITLE
steamdeck/graphical: use correct monitor identifier

### DIFF
--- a/modules/steamdeck/graphical.nix
+++ b/modules/steamdeck/graphical.nix
@@ -38,7 +38,7 @@ in
     (mkIf cfg.enableXorgRotation {
       environment.etc."X11/xorg.conf.d/90-jovian.conf".text = ''
         Section "Monitor"
-          Identifier     "eDP"
+          Identifier     "eDP-1"
           Option         "Rotate"    "right"
         EndSection
 


### PR DESCRIPTION
Fixes https://github.com/Jovian-Experiments/Jovian-NixOS/issues/103

I use Plasma with wayland so I haven't tested this with a DE, but it works in SDDM