### PR TITLE
modules/overlay: add assertion to make sure we're building on 23.11 or higher

### DIFF
--- a/modules/overlay.nix
+++ b/modules/overlay.nix
@@ -1,7 +1,14 @@
-{ lib, pkgs, ... }:
+{ lib, ... }:
 
 {
   nixpkgs.overlays = [
     (import ../overlay.nix)
+  ];
+
+  assertions = [
+    {
+      assertion = lib.versionAtLeast lib.version "23.11";
+      message = "Jovian NixOS is only validated with the nixos-unstable branch of Nixpkgs. Please upgrade your Nixpkgs version.";
+    }
   ];
 }


### PR DESCRIPTION
Avoids things like #217.