### PR TITLE
fix: remove unnecessary desktopsesison warning

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -66,16 +66,6 @@ in
         }
       ];
 
-      warnings = lib.optional (cfg.desktopSession == null) ''
-        jovian.steam.desktopSession is unset.
-
-        This means that using the Switch to Desktop function in Gaming Mode will
-        relaunch Gaming Mode.
-
-        Set jovian.steam.desktopSession to the name of a desktop session, or "steam-wayland"
-        to keep this behavior.
-      '';
-
       services.xserver = {
         enable = true;
         displayManager.lightdm.enable = false;


### PR DESCRIPTION
since https://github.com/Jovian-Experiments/Jovian-NixOS/pull/201 is merged, the waning on null check of desktopsesison no longer make sense, remove it would make sense.

this closes https://github.com/Jovian-Experiments/Jovian-NixOS/issues/221