### PR TITLE
fix: rewording desktopSession warning

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -36,8 +36,8 @@ in
               lib.assertMsg (userProvidedDesktopSession != null -> (str.check userProvidedDesktopSession && lib.elem userProvidedDesktopSession config.services.xserver.displayManager.sessionData.sessionNames)) ''
                   Desktop session '${userProvidedDesktopSession}' not found.
                   Valid values for 'jovian.steam.desktopSession' are:
-                    ${lib.concatStringsSep "\n  " (lib.lists.remove "gamescope-wayland" config.services.xserver.displayManager.sessionData.sessionNames)}
-                  If you don't want a desktop session to switch to, remove 'jovian.steam.desktopSession' from your config.
+                    ${lib.concatStringsSep "\n  " config.services.xserver.displayManager.sessionData.sessionNames}
+                  If you don't want a desktop session to switch to, set 'jovian.steam.desktopSession' to 'gamescope-wayland'.
               '';
           };
           default = null;
@@ -45,8 +45,7 @@ in
           description = lib.mdDoc ''
             The session to launch for Desktop Mode.
 
-            By default, attempting to switch to the desktop will launch
-            Gaming Mode again.
+            By default, attempting to switch to the desktop will launch Gaming Mode again.
           '';
         };
       };
@@ -72,7 +71,7 @@ in
         This means that using the Switch to Desktop function in Gaming Mode will
         relaunch Gaming Mode.
 
-        Set jovian.steam.desktopSession to the name of a desktop session, or "steam-wayland"
+        Set jovian.steam.desktopSession to the name of a desktop session, or "gamescope-wayland"
         to keep this behavior.
       '';
 


### PR DESCRIPTION
keep the default null and warning people on null setting, also suggest corrects to "gamescope-wayland" if no desktop is intended. closes https://github.com/Jovian-Experiments/Jovian-NixOS/issues/221