### PR TITLE
steamdeck-bios-fwupd: Complete Galileo support

### DIFF
--- a/pkgs/jupiter-hw-support/SteamDeckBIOS.metainfo.xml
+++ b/pkgs/jupiter-hw-support/SteamDeckBIOS.metainfo.xml
@@ -2,8 +2,12 @@
 <component type="firmware">
   <id>unofficial.valve.steamdeck.@board@.BIOS</id>
   <name>Steam Deck (@model@)</name>
+  <requires>
+    <id compare="ge" version="1.0.1">org.freedesktop.fwupd</id>
+    <hardware>@hwid@</hardware>
+  </requires>
   <provides>
-    <firmware type="flashed">@guid@</firmware>
+    <firmware type="flashed">@uefi_guid@</firmware>
   </provides>
   <custom>
     <value key="LVFS::UpdateProtocol">org.uefi.capsule</value>

--- a/pkgs/jupiter-hw-support/bios-fwupd.nix
+++ b/pkgs/jupiter-hw-support/bios-fwupd.nix
@@ -16,7 +16,7 @@
 # Board prefixes to build the output for.
 , boards ? [
   "F7A" # Jupiter
-  #"F7G" # Galileo
+  "F7G" # Galileo
 ]
 
 # Directory containing the BIOS files.
@@ -56,15 +56,25 @@ in runCommand "steamdeck-bios-fwupd-${version}" {
 
     >&2 echo ":: Detected numeric BIOS version $versionNumber"
 
+    uefi_guid=bbb1cf06-f7b9-4466-adcc-6b8815bd99e6
+
+    # Run `fwupdtool hwids`
+    # Manufacturer + Family + ProductName
     case "$board" in
       F7A)
-        guid=bbb1cf06-f7b9-4466-adcc-6b8815bd99e6
+        # Manufacturer: Valve
+        # Family: Aerith
+        # ProductName: Jupiter
+        hwid=c92f10e2-b04e-59fd-9a1c-e9f354fe80d0
         model="LCD [Jupiter]"
         ;;
-      #F7G)
-      #  guid=00000000-0000-0000-0000-000000000000
-      #  model="OLED [Galileo]"
-      #  ;;
+      F7G)
+        # Manufacturer: Valve
+        # Family: Sephiroth
+        # ProductName: Galileo
+        hwid=642e9dd3-94fe-5b66-a403-5e765427de87
+        model="OLED [Galileo]"
+        ;;
       *)
         >&2 echo ":: No GUID for board '$board'"
         exit 1
@@ -73,7 +83,8 @@ in runCommand "steamdeck-bios-fwupd-${version}" {
 
     export model
     export board
-    export guid
+    export hwid
+    export uefi_guid
     export filename=$(basename "$biosFile")
     export sha1=$(sha1sum "$biosFile" | awk '{ print $1 }')
     export sha256=$(sha1sum "$biosFile" | awk '{ print $1 }')


### PR DESCRIPTION
Follow up to the work in #215. Tested updating from F7G0101 to F7G0105 on the OLED edition.

Ref: #227

---

**Warning**: Before you do anything, run `galileo-mura-extractor` in the `galileo-mura` package. Save the resulting `/tmp/mura/blob.tar` which should be a tarball with PNGs inside. This tarball contains mura compensation data which may not be replaceable. I did the update and now the dumped file only contains 0xff.

Edit: This is likely a false alarm. Turns out my Deck has a BOE panel which [doesn't require mura correction](https://github.com/Jovian-Experiments/galileo-mura/blob/80551486ea4bc353938f8f2030dd4cd8451fa690/galileo-mura-setup#L19). It's plausible that such Decks don't have correction data in the first place either.