### PR TITLE
steamdeck/perf-control: Add brightness paths for Galileo

### DIFF
--- a/modules/steamdeck/perf-control.nix
+++ b/modules/steamdeck/perf-control.nix
@@ -31,7 +31,9 @@ in
     services.udev.extraRules = ''
       # Enables brightness slider in Steam
       # - /sys/class/backlight/amdgpu_bl0/brightness
+      # - /sys/devices/platform/AMDI0010:02/i2c-2/i2c-ANX7580A:00/{brightness,bmode} (Galileo?)
       ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="amdgpu_bl0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
+      ACTION=="add", SUBSYSTEM=="i2c", KERNEL=="i2c-ANX7580A:00", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/%p/brightness /sys/%p/bmode"
 
       # Enables manual GPU clock control in Steam
       # - /sys/class/drm/card0/device/power_dpm_force_performance_level


### PR DESCRIPTION
Steam on the OLED edition seems to use those paths associated with Valve's `anx7580` driver.

- https://github.com/Jovian-Experiments/jupiter-hw-support/commit/5ed4cda3c915e4af835c3ce9c63ff4e7bb9f8eb8
- `bmode`: https://github.com/Jovian-Experiments/linux/blob/6.1.52-valve5/drivers/gpu/drm/bridge/analogix/anx7580.c#L275-L316

Ref: #227