### PR TITLE
linux-jovian: 6.1.52-valve5 -> 6.1.52-valve9

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -4,7 +4,7 @@ let
   inherit (lib) versions;
 
   kernelVersion = "6.1.52";
-  vendorVersion = "valve5";
+  vendorVersion = "valve9";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";
@@ -138,7 +138,7 @@ buildLinux (args // rec {
     owner = "Jovian-Experiments";
     repo = "linux";
     rev = version;
-    hash = "sha256-XNGX/ETGWVA1dQA7A+DUv8oW3PgdO4RJn9p2P1pC1FQ=";
+    hash = "sha256-UvJD2UJ3rsVk2wWMQ7Tu6QMxDfX7AzEMxtBIjBC1WIA=";
 
     # Sometimes the vendor doesn't update the EXTRAVERSION tag.
     # Let's fix it up in post.


### PR DESCRIPTION
Contains a fix for audio after resume: https://github.com/Jovian-Experiments/linux/commit/c0c65da7ca4b0a4f93272f5e932dd7eed90703c8

Ref: #227

 - https://github.com/Jovian-Experiments/linux/compare/6.1.52-valve5...6.1.52-valve9