### PR TITLE
Wire up Mura correction data extraction for Galileo

### DIFF
--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -23,6 +23,13 @@ in
         source = "${pkgs.gamescope}/bin/gamescope";
         capabilities = "cap_sys_nice+pie";
       };
+
+      security.wrappers.galileo-mura-extractor = {
+        owner = "root";
+        group = "root";
+        source = "${pkgs.galileo-mura}/bin/galileo-mura-extractor";
+        setuid = true;
+      };
     }
     {
       hardware.opengl.driSupport32Bit = true;

--- a/pkgs/galileo-mura/default.nix
+++ b/pkgs/galileo-mura/default.nix
@@ -3,6 +3,7 @@
 , fetchFromGitHub
 , meson
 , ninja
+, wrappersDir ? "/run/wrappers/bin"
 }:
 
 stdenv.mkDerivation rec {
@@ -20,6 +21,10 @@ stdenv.mkDerivation rec {
     meson
     ninja
   ];
+
+  postInstall = ''
+    sed -i 's|/usr/bin/galileo-mura-extractor|${wrappersDir}/galileo-mura-extractor|g' $out/bin/galileo-mura-setup
+  '';
 
   meta = with lib; {
     description = "";


### PR DESCRIPTION
OLED Steam Decks with Samsung (SDC) panels have Mura correction maps from the factory, shipped as [a tarball with PNG images at 0xffaa0000](https://github.com/Jovian-Experiments/galileo-mura/blob/80551486ea4bc353938f8f2030dd4cd8451fa690/main.c#L184). Gamescope can use those maps to compensate for the Mura effect.

Can't really test since my Deck has a BOE panel (Limited Edition, 1TB) without Mura correction data.

Ref: #227