### PR TITLE
mesa-radv-jupiter: Sync with nixpkgs, use llvmPackages from mesa

### DIFF
--- a/pkgs/mesa-radv-jupiter/default.nix
+++ b/pkgs/mesa-radv-jupiter/default.nix
@@ -78,6 +78,7 @@
 , zstd
 , directx-headers
 , udev
+, mesa
 }:
 
 /** Packaging design:
@@ -97,7 +98,7 @@ let
 
   withLibdrm = lib.meta.availableOn stdenv.hostPlatform libdrm;
 
-  llvmPackages = llvmPackages_16;
+  llvmPackages = mesa.llvmPackages;
   # Align all the Mesa versions used. Required to prevent explosions when
   # two different LLVMs are loaded in the same process.
   # FIXME: these should really go into some sort of versioned LLVM package set


### PR DESCRIPTION
Updated to match nixpkgs 6247bd08f7db9abaa63fbd8122f2cb6179630da0.

Mismatched LLVM versions seems to cause segfaults in some games.