### PR TITLE
Do not expand path var during decky installation

### DIFF
--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -127,7 +127,7 @@ let
       mkdir $out/bin
       cat << EOF >$out/bin/decky-loader
       #!/bin/sh
-      export PATH=${pythonEnv}/bin:$PATH
+      export PATH=${pythonEnv}/bin:\$PATH
       export DECKY_VERSION=v${version}
       exec ${pythonEnv}/bin/python3 $out/lib/decky-loader/main.py
       EOF


### PR DESCRIPTION
When writing launcher script build env $PATH is written because bash expands it. By escaping we will propagate PATH from systemd unit instead of build time path.

Example of current build on my system:
```
#!/nix/store/q1c2flcykgr4wwg5a6h450hxbk4ch589-bash-5.2-p15/bin/sh
export PATH=/nix/store/p9dwjwvranqig7z5c3vl1rmk0mnq2ryf-python3-3.11.6-env/bin:/nix/store/85jldj870vzcl72yz03labc93bwvqayx-patchelf-0.15.0/bin:/nix/store/90h6k8ylkgn81k10190v5c9ldyjpzgl9-gcc-wrapper-12.3.0/bin:/nix/store/hf2gy3km07d5m0p1lwmja0rg9wlnmyr7-gcc-12.3.0/bin:/nix/store/cx01qk0qyylvkgisbwc7d3pk8sliccgh-glibc-2.38-27-bin/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/1alqjnr40dsk7cl15l5sn5y2zdxidc1v-binutils-wrapper-2.40/bin:/nix/store/1fn92b0783crypjcxvdv6ycmvi27by0j-binutils-2.40/bin:/nix/store/p9dwjwvranqig7z5c3vl1rmk0mnq2ryf-python3-3.11.6-env/bin:/nix/store/bblyj5b3ii8n6v4ra0nb37cmi3lf8rz9-coreutils-9.3/bin:/nix/store/l974pi8a5yqjrjlzmg6apk0jwjv81yqw-findutils-4.9.0/bin:/nix/store/8q25nyfirzsng6p57yp8hsaldqqbc7dg-diffutils-3.10/bin:/nix/store/9c5qm297qnvwcf7j0gm01qrslbiqz8rs-gnused-4.9/bin:/nix/store/rx2wig5yhpbwhnqxdy4z7qivj9ln7fab-gnugrep-3.11/bin:/nix/store/7wfya2k95zib8jl0jk5hnbn856sqcgfk-gawk-5.2.2/bin:/nix/store/xpidksbd07in3nd4sjx79ybwwy81b338-gnutar-1.35/bin:/nix/store/202iqv4bd7lh6f7fpy48p7q4d96lqdp7-gzip-1.13/bin:/nix/store/ik7jardq92dxw3fnz3vmlcgi9c8dwwdq-bzip2-1.0.8-bin/bin:/nix/store/v4iswb5kwj33l46dyh2zqh0nkxxlr3mz-gnumake-4.4.1/bin:/nix/store/q1c2flcykgr4wwg5a6h450hxbk4ch589-bash-5.2-p15/bin:/nix/store/cbj1ph7zi009m53hxs90idl1f5i9i941-patch-2.7.6/bin:/nix/store/76z4cjs7jj45ixk12yy6k5z2q2djk2jb-xz-5.4.4-bin/bin:/nix/store/qmfxld7qhk8qxlkx1cm4bkplg1gh6jgj-file-5.45/bin
export DECKY_VERSION=v2.10.5
exec /nix/store/p9dwjwvranqig7z5c3vl1rmk0mnq2ryf-python3-3.11.6-env/bin/python3 /nix/store/rygj484l6xzjdcmxd5qn73v1l2rp1csc-decky-loader-2.10.5/lib/decky-loader/main.py
```
As you see export PATH contains gnu make and binutils, which is available in build phase.