### PR TITLE
modules/decky-loader: Add pkg paths to LD_LIBRARY_PATH

### DIFF
--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -84,7 +84,9 @@ in
       # run plugins. Running as non-root is unsupported and currently breaks:
       #
       # <https://github.com/SteamDeckHomebrew/decky-loader/issues/446#issuecomment-1637177368>
-      systemd.services.decky-loader = {
+      systemd.services.decky-loader = let
+        pathPkgs = with pkgs; [ coreutils gawk ] ++ cfg.extraPackages;
+      in {
         description = "Steam Deck Plugin Loader";
 
         wantedBy = [ "multi-user.target" ];
@@ -96,9 +98,10 @@ in
           UNPRIVILEGED_PATH = cfg.stateDir;
           PLUGIN_PATH = "${cfg.stateDir}/plugins";
           PYTHONPATH = "${python.withPackages cfg.extraPythonPackages}/${python.sitePackages}";
+          LD_LIBRARY_PATH = lib.makeLibraryPath pathPkgs;
         };
 
-        path = with pkgs; [ coreutils gawk ] ++ cfg.extraPackages;
+        path = pathPkgs;
 
         preStart = ''
           mkdir -p "${cfg.stateDir}"


### PR DESCRIPTION
Certain plugins require additional libraries to work - e.g. Volume Mixer needs libpulseaudio to work. This generates a list of lib paths for LD_LIBRARY_PATH using the same args passed to `path`.