### PR TITLE
modules/decky-loader: Add enableFHSEnvironment option

### DIFF
--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -22,6 +22,14 @@ in
           '';
         };
 
+        enableFHSEnvironment = mkOption {
+          type = types.bool;
+          default = false;
+          description = lib.mdDoc ''
+            Allows plugins shipping with prebuilt binaries to function (e.g. PowerTools).
+          '';
+        };
+
         package = mkOption {
           type = types.package;
           default = pkgs.decky-loader;
@@ -105,8 +113,16 @@ in
           chown -R "${cfg.user}:" "${cfg.stateDir}"
         '';
 
-        serviceConfig = {
-          ExecStart = "${cfg.package}/bin/decky-loader";
+        serviceConfig = let
+          decky-loader = if !cfg.enableFHSEnvironment then
+            "${cfg.package}"
+          else
+            pkgs.buildFHSEnv {
+              name = "decky-loader";
+              runScript = "${cfg.package}/bin/decky-loader";
+            };
+        in {
+          ExecStart = "${decky-loader}/bin/decky-loader";
           KillSignal = "SIGINT";
         };
       };


### PR DESCRIPTION
Some plugins ship with a precompiled binary necessitating an FHS env to run them - PowerTools is one such instance where it comes with a compiled backend binary in Rust.

This adds an `enableFHSEnvironment` option for such cases and conditionally enables a blank FHS environment in the systemd unit. I haven't encountered any issues with other plugins with this turned on.