### PR TITLE
Re-enable Cachix action in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,15 @@ jobs:
       - name: Setup automatic caching
         uses: DeterminateSystems/magic-nix-cache-action@v2
 
+      - name: Enable Cachix
+        uses: cachix/cachix-action@v12
+        if: >
+          github.repository_owner == 'Jovian-Experiments' &&
+          github.ref == 'refs/heads/development'
+        with:
+          name: jovian-nixos
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+
       - name: Install nix-build-uncached
         # Save evaluation time by pulling directly from cache.nixos.org
         # nixpkgs rev 12303c652b881435065a98729eb7278313041e49


### PR DESCRIPTION
With d55977e, pushing to Cachix was replaced with GitHub Actions cache to speed up the CI and make it work in forks. However, it is not possible to use GitHub cache outside CI.  
Some packages, like the kernel, take a substantial amount of time to compile and is therefore kinda of a waste that the artifacts already built by the CI cannot be downloaded.

The changes proposed here re-introduce the Cachix action, only for commits in the default branch and not in forks.