### PR TITLE
powerbuttond: Update to Jovian fork with environment patch

### DIFF
--- a/pkgs/powerbuttond/default.nix
+++ b/pkgs/powerbuttond/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "powerbuttond";
-    rev = "v2";
-    hash = "sha256-syeVkiD42QM3wkE0iqfS5+Z3hqh1reqCWGnTR3BGXV4=";
+    rev = "d31bbe457f6e4ae641f555b48b9d64b6c6311191"; # jovian/v2
+    hash = "sha256-T/9AhRYw6v/WvtUaTegBdvR3HWTUFDY6ztQtol9YDwI=";
   };
 
   patches = [


### PR DESCRIPTION
With this change, the power button in use can be configured via an environment variable (POWERBUTTOND_DEVICE).

See:

 - https://github.com/Jovian-Experiments/powerbuttond/compare/v2...jovian/v2

* * *

This is not (yet?) exposed as a configuration option since it might not be the correct way forward (imo).

The correct way forward would be to listen to all input devices exposing `KEY_POWER`, such that intrinsically it works with any system.

cc @appsforartists (legion go)

Can be configured like this:

```nix
{
  systemd.user.services.gamescope-session.environment = lib.mkForce {
    POWERBUTTOND_DEVICE = "/dev/input/event8";
  };
}
```

`mkForce` necessary because of this one:

 - https://github.com/Jovian-Experiments/Jovian-NixOS/blob/4d24d2ff927a8b8a698bbacdb1966045bcadf872/modules/steam/autostart.nix#L88

* * *

Side-note: some devices may not expose presses until the button is released, making it impossible for `powerbuttond` to detect long press like it does on the Steam Deck. (Observed on GPD Win Mini.)