### PR TITLE
powerbuttond: Listen to any KEY_POWER event

### DIFF
--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -48,7 +48,7 @@ in
 
       services.xserver.displayManager.sessionPackages = [ pkgs.gamescope-session ];
 
-      # Conflicts with power-button-handler
+      # Conflicts with powerbuttond
       services.logind.extraConfig = ''
         HandlePowerKey=ignore
       '';

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -53,6 +53,10 @@ in
         HandlePowerKey=ignore
       '';
 
+      services.udev.packages = [
+        pkgs.powerbuttond
+      ];
+
       # This rule allows the user to configure Wi-Fi in Deck UI.
       #
       # Steam modifies the system network configs via

--- a/modules/steamdeck/controller.nix
+++ b/modules/steamdeck/controller.nix
@@ -29,10 +29,7 @@ in
   config = mkMerge [
     (mkIf (cfg.enableControllerUdevRules) {
       # Necessary for the controller parts to work correctly.
-      services.udev.extraRules = ''
-        # This rule is needed by the vendor power-button-handler.py
-        SUBSYSTEM=="input", ATTRS{phys}=="isa0060/serio0/input0", MODE="0660", TAG+="uaccess"
-      '' + lib.optionalString (!config.hardware.steam-hardware.enable) ''
+      services.udev.extraRules = lib.optionalString (!config.hardware.steam-hardware.enable) ''
         # This rule is necessary for gamepad emulation.
         KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"
 

--- a/pkgs/powerbuttond/default.nix
+++ b/pkgs/powerbuttond/default.nix
@@ -14,8 +14,8 @@ stdenv.mkDerivation {
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "powerbuttond";
-    rev = "v2";
-    hash = "sha256-syeVkiD42QM3wkE0iqfS5+Z3hqh1reqCWGnTR3BGXV4=";
+    rev = "ef6d214295a38f186bba9a80cc6f48c055700e3a"; # jovian/multi
+    hash = "sha256-SD8NpiBIIvI59/HtV19lsJ8/SdBOoyO2rH1OVmDX5Q8=";
   };
 
   patches = [
@@ -25,16 +25,18 @@ stdenv.mkDerivation {
     })
   ];
 
+  postPatch = ''
+    substituteInPlace Makefile \
+      --replace '/usr/lib/hwsupport/powerbuttond' '/usr/bin/powerbuttond' \
+      --replace '/usr/' '/'
+  '';
+
   nativeBuildInputs = [pkg-config];
   buildInputs = [libevdev];
 
-  installPhase = ''
-    runHook preInstall
-
-    install -D -m 555 powerbuttond $out/bin/powerbuttond
-
-    runHook postInstall
-  '';
+  makeFlags = [
+    "DESTDIR=$(out)"
+  ];
 
   meta = with lib; {
     description = "Steam Deck power button daemon";


### PR DESCRIPTION
With the added in-package udev rules, this makes `powerbuttond` more self-contained, and more universal.

See:

 - https://github.com/Jovian-Experiments/powerbuttond/compare/v2...jovian/multi

We can also add any missing power button devices to the rules, assuming this doesn't already pick all of them.


This is the correct way to solve #256 and #234.

Fixes #234

* * *

Note that since this involves udev, it should be tested from a fresh boot.

### What was done
 
 - Tested on GPD Win Mini (only short presses can work, the power button does not report discrete press/release events)
 - Tested on Steam Deck