### PR TITLE
steam: Allow overriding environment for gamescope session

### DIFF
--- a/modules/steam/default.nix
+++ b/modules/steam/default.nix
@@ -10,6 +10,7 @@ in
   imports = [
     ./steam.nix
     ./autostart.nix
+    ./environment.nix
   ];
   options = {
     jovian = {

--- a/modules/steam/environment.nix
+++ b/modules/steam/environment.nix
@@ -1,0 +1,41 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    concatStringsSep
+    escapeShellArg
+    mapAttrsToList
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+
+  cfg = config.jovian.steam;
+in
+{
+  options = {
+    jovian.steam = {
+      environment = mkOption {
+        type = with types; attrsOf str;
+        default = {};
+        description = ''
+          Additional environment variables or overrides to environment variables
+          that will be applied to the gamescope session.
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enable (mkMerge [
+    {
+      environment.etc."xdg/gamescope-session/environment" = {
+        text = concatStringsSep "\n" (
+          mapAttrsToList (
+            key: value:
+            "export ${escapeShellArg key}=${escapeShellArg value}"
+          ) cfg.environment
+        );
+      };
+    }
+  ]);
+}

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -72,6 +72,13 @@ in
           }
         });
       '';
+
+      jovian.steam.environment = {
+        # We don't support adopting a drive, yet.
+        STEAM_ALLOW_DRIVE_ADOPT = mkDefault "0";
+        # Ejecting doesn't work, either.
+        STEAM_ALLOW_DRIVE_UNMOUNT = mkDefault "0";
+      };
     }
   ]);
 }

--- a/pkgs/gamescope-session/0001-gamescope-session-Add-xdg-environment-overrides.patch
+++ b/pkgs/gamescope-session/0001-gamescope-session-Add-xdg-environment-overrides.patch
@@ -1,0 +1,29 @@
+From f309bbee6de87dac8e96e99aa6fbb9af434bc8aa Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Fri, 5 Jan 2024 16:14:21 -0500
+Subject: [PATCH] gamescope-session: Add xdg environment overrides
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ gamescope-session | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/gamescope-session b/gamescope-session
+index 2305288..53b5e79 100755
+--- a/gamescope-session
++++ b/gamescope-session
+@@ -300,6 +300,11 @@ short_session_duration=60
+ short_session_count_before_reset=3
+ SECONDS=0
+ 
++# Jovian NixOS environment overrides hook
++if test -e /etc/xdg/gamescope-session/environment; then
++	. /etc/xdg/gamescope-session/environment;
++fi
++
+ short_session_count=$(< "$short_session_tracker_file" wc -l)
+ 
+ if [[ "$short_session_count" -ge "$short_session_count_before_reset" ]]; then
+-- 
+2.42.0
+

--- a/pkgs/gamescope-session/default.nix
+++ b/pkgs/gamescope-session/default.nix
@@ -61,6 +61,9 @@ let
     fake = {
       # we're using wrappers for these
       external = [ "sudo" "gamescope" ];
+      source = [
+        "/etc/xdg/gamescope-session/environment"
+      ];
     };
     fix = {
       "/usr/bin/ibus-daemon" = true;
@@ -73,6 +76,7 @@ let
       # if you've somehow managed to get devkit Steam on your NixOS,
       # everything that happens beyond this point is entirely your fault
       "$HOME/devkit-game/devkit-steam" = true;
+      "source:/etc/xdg/gamescope-session/environment" = true;
     };
 
     prologue = "${writeText "gamescope-session-prologue" ''
@@ -107,9 +111,11 @@ in stdenv.mkDerivation(finalAttrs: {
     hash = "sha256-NOpTVCSSufqsnjccEVAx9aQ4/eKcDsryjB7SI1rf3HA=";
   };
 
-  patchPhase = ''
-    runHook prePatch
+  patches = [
+    ./0001-gamescope-session-Add-xdg-environment-overrides.patch
+  ];
 
+  postPatch = ''
     patchShebangs steam-http-loader
 
     substituteInPlace gamescope-session \
@@ -118,8 +124,6 @@ in stdenv.mkDerivation(finalAttrs: {
 
     substituteInPlace gamescope-session.service \
       --replace /usr/bin $out/bin
-
-    runHook postPatch
   '';
 
   nativeBuildInputs = [python3];


### PR DESCRIPTION
The actual goal here was (first) disabling features on non-steamdeck devices.

Though, while peeking at the current set of variables, I saw a good opportunity for a demo: disabling the non-working adopt/unmount features.

There are two minor things I don't like in here:

 - ~~The way it's being injected in `gamescope-session`... `substituteInPlace --replace` is kinda brittle with regards to replacements not being made...~~
 - It's possible to provide invalid attrnames for the environment, but since they are escaped, it would, at worst, be caught "correctly"
    ```
    -bash: export: `test; exit1=0': not a valid identifier
    ```


~~At the very least, I want opinions about the way it is injected in the `gamescope-session` script. It *has* to happen before stuff is being launched.~~

Moved injection to a patch. If it fails to apply, `--replace` probably would have too, anyway...