### PR TITLE
decky-loader: add a separate package tracking the prerelease branch

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -102,5 +102,6 @@ rec {
 
   sdgyrodsu = final.callPackage ./pkgs/sdgyrodsu { };
 
-  decky-loader = final.callPackage ./pkgs/decky-loader { };
+  decky-loader = final.callPackage ./pkgs/decky-loader/stable.nix { };
+  decky-loader-prerelease = final.callPackage ./pkgs/decky-loader/prerelease.nix { };
 }

--- a/pkgs/decky-loader/generic.nix
+++ b/pkgs/decky-loader/generic.nix
@@ -1,3 +1,4 @@
+{ version, hash, npmHash }:
 { lib
 , stdenv
 , fetchFromGitHub
@@ -7,10 +8,6 @@
 , python3
 }:
 let
-  version = "2.10.14";
-  hash = "sha256-ydD5hcTNLsBteipdiJGWqK9TGqE1uvP2pMp+HfBUkxk=";
-  npmHash = "sha256-UYfZDgDjgYTqe/IxAet+NkjfaeYhJIoCg368ykaMxSE=";
-
   src = fetchFromGitHub {
     owner = "SteamDeckHomebrew";
     repo = "decky-loader";

--- a/pkgs/decky-loader/prerelease.nix
+++ b/pkgs/decky-loader/prerelease.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  version = "2.10.15-pre1";
+  hash = "sha256-ChzGrTqrChxZoMqPyvlaPXDzNhcxoTLgCXp7ehZAKsI=";
+  npmHash = "sha256-uXQ4jUdkvexD3l1I0nBDr1Xa5o9+CCOzMYD0gAQxnGA=";
+}

--- a/pkgs/decky-loader/stable.nix
+++ b/pkgs/decky-loader/stable.nix
@@ -1,0 +1,5 @@
+import ./generic.nix {
+  version = "2.10.14";
+  hash = "sha256-ydD5hcTNLsBteipdiJGWqK9TGqE1uvP2pMp+HfBUkxk=";
+  npmHash = "sha256-UYfZDgDjgYTqe/IxAet+NkjfaeYhJIoCg368ykaMxSE=";
+}


### PR DESCRIPTION
Since we end up using it way too often and I don't want to carry a patch forever.