### PR TITLE
Add support for using the BGRT in the updater applet

### DIFF
--- a/modules/steam/updater.nix
+++ b/modules/steam/updater.nix
@@ -18,6 +18,7 @@ in
         type = types.enum [
           "steamos"
           "jovian"
+          "bgrt"
           "vendor"
         ];
         default = "steamos";
@@ -27,6 +28,8 @@ in
           When `steamos`, this will use the vendor-selected image, scaled appropriately.
 
           When `jovian`, this will use the Jovian Experiments logo, scaled appropriately.
+
+          When `bgrt`, the BGRT (UEFI vendor logo) will be used.
 
           When `vendor`, the vendor default will not be changed. This differs from `default` in that
           on systems other than the Steam Deck, the scaling may not be correct.
@@ -67,6 +70,9 @@ in
           ''}
           ${optionalString (cfg.updater.splash == "jovian") ''
             jovian_updater_logo="${../../artwork/logo/splash.png}"
+          ''}
+          ${optionalString (cfg.updater.splash == "bgrt") ''
+            jovian_updater_logo="--bgrt"
           ''}
 
           ${pkgs.jovian-updater-logo-helper}/bin/jovian-updater-logo-helper "$jovian_updater_logo" "/run/jovian/steam-splash.png"

--- a/modules/steam/updater.nix
+++ b/modules/steam/updater.nix
@@ -53,6 +53,12 @@ in
           RemainAfterExit = true;
         };
         script = ''
+          # Ignore errors (`set -e` is added helpfully for us)
+          set +e
+
+          # Except we want to fail early still...
+          (
+          set -e
           mkdir -p /run/jovian
 
           ${optionalString (cfg.updater.splash == "steamos") ''
@@ -76,6 +82,10 @@ in
           ''}
 
           ${pkgs.jovian-updater-logo-helper}/bin/jovian-updater-logo-helper "$jovian_updater_logo" "/run/jovian/steam-splash.png"
+          )
+
+          # Ensure this always terminates successfully, even if the logo thing failed
+          true
         '';
       };
       environment.etc."xdg/gamescope-session/environment" = {

--- a/pkgs/jovian-updater-logo-helper/jovian-updater-logo-helper.sh
+++ b/pkgs/jovian-updater-logo-helper/jovian-updater-logo-helper.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+#
+# Tips for debugging:
+#
+#  - Pass `'canvas:red[128x64!]'` as the input image.
+#
+
 set -e
 set -u
 PS4=" $ "

--- a/pkgs/jovian-updater-logo-helper/jovian-updater-logo-helper.sh
+++ b/pkgs/jovian-updater-logo-helper/jovian-updater-logo-helper.sh
@@ -49,16 +49,89 @@ MAGICK_INVOCATION=(
 
 	# Create an empty image, with the panel-native resolution
 	"canvas:black[${image_width}x${image_height}!]"
+
+	# Switch default composition gravity to top-left
+	-gravity NorthWest
 )
 
-MAGICK_INVOCATION+=(
-	# Add the logo
-	"$logo"
-	# Centered
-	-gravity center
-	# (This means 'add')
-	-composite
-)
+if [[ "$logo" == "--bgrt" ]]; then
+	# Status field described here:
+	#  - https://uefi.org/htmlspecs/ACPI_Spec_6_4_html/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#boot-graphics-resource-table-bgrt
+	bgrt_rotation="$(( ($(cat /sys/firmware/acpi/bgrt/status) >> 1) & 2#11 ))"
+	bgrt_xoffset=$(cat /sys/firmware/acpi/bgrt/xoffset)
+	bgrt_yoffset=$(cat /sys/firmware/acpi/bgrt/yoffset)
+	bgrt_dimensions="$(magick identify /sys/firmware/acpi/bgrt/image  | cut -d' ' -f3)"
+	bgrt_height=${bgrt_dimensions#*x}
+	bgrt_width=${bgrt_dimensions%x*}
+
+	case "$bgrt_rotation" in
+	"$(( 2#00 ))")
+		bgrt_offset="+$((
+			bgrt_xoffset
+		))+$((
+			bgrt_yoffset
+		))"
+		bgrt_counter_rotation="0"
+		;;
+	"$(( 2#01 ))") #  90
+		bgrt_offset="+$((
+			bgrt_yoffset
+		))+$((
+			image_width - bgrt_width - bgrt_xoffset
+		))"
+		bgrt_counter_rotation="-90"
+		;;
+	"$(( 2#10 ))") # 180
+		bgrt_offset="+$((
+			image_width - bgrt_width - bgrt_xoffset
+		))+$((
+			image_height - bgrt_height - bgrt_yoffset
+		))"
+		bgrt_counter_rotation="180"
+		;;
+	"$(( 2#11 ))") # -90
+		bgrt_offset="+$((
+			image_height - bgrt_height - bgrt_yoffset
+		))+$((
+			bgrt_xoffset
+		))"
+		bgrt_counter_rotation="90"
+	;;
+	esac
+
+	MAGICK_INVOCATION+=(
+		# Put the canvas back into the panel native orientation.
+		-rotate $(( display_rotation ))
+
+		# Add the BGRT (bmp image)
+		# Group operation so we don't operate on the canvas.
+		'('
+			# Load the image
+			"/sys/firmware/acpi/bgrt/image"
+
+			# Rotate the BGRT to its expected rotation for composition
+			-rotate $(( bgrt_counter_rotation ))
+
+			# At its defined offset, again considering pre-composed rotation
+			-geometry "$bgrt_offset"
+		')'
+
+		# (This means 'add' for the previous image)
+		-composite
+
+		# Undo the native orientation we added back.
+		-rotate -$(( display_rotation ))
+	)
+else
+	MAGICK_INVOCATION+=(
+		# Add the logo
+		"$logo"
+		# Centered
+		-gravity center
+		# (This means 'add')
+		-composite
+	)
+fi
 
 # Final fixups to the image
 MAGICK_INVOCATION+=(


### PR DESCRIPTION
Builds on top of #438

* * *

This is more relevant to non-steamdeck hardware.

* * *

This brings these changes (as options) to the updater logo.


### BGRT logo continuation

The first feature, and maybe the most important one, is that we can use the BGRT logo as the source for the logo in the updater.

This, when paired with e.g. HackBGRT, allows a more subtle in-depth integration up to and including the updater applet.

It may be preferable to move to the BGRT outright, while using a proper plymouth theme, too.

~~(There will be ranting in an upcoming plymouth-related PR...)~~

* * *

Also fixes #443.