### PR TITLE
decky-loader-prerelease: 2.11.1 -> 2.12.0-pre1

### DIFF
--- a/pkgs/decky-loader/prerelease.nix
+++ b/pkgs/decky-loader/prerelease.nix
@@ -1,5 +1,5 @@
 import ./generic.nix {
-  version = "2.11.1";
-  hash = "sha256-Jf4P7w43MlDo+o7kNZYagMn0UbJfhp4L7Xwjbep9AUQ=";
-  npmHash = "sha256-GJ+isvwi0wfMfQusH5F3mUA9hEdZO9Pvw9Qm5+Iv34w=";
+  version = "2.12.0-pre1";
+  hash = "sha256-g4vntKPdaBr8NWdOHlZJkSajHk3oeCQJMsdCWyhFaBE=";
+  npmHash = "sha256-lv5xhCcOXHqA0ILRnknAryMeTL+qqXaPu9zoZ5FLbmo=";
 }


### PR DESCRIPTION
Works with latest Steam beta