### PR TITLE
hardware/amd: allow access to all brightness devices, not just amdgpu_bl0

### DIFF
--- a/modules/hardware/amd/default.nix
+++ b/modules/hardware/amd/default.nix
@@ -52,8 +52,7 @@ in
     (mkIf (cfg.gpu.enableBacklightControl) {
       # Enables brightness slider in Steam
       services.udev.extraRules = ''
-        # - /sys/class/backlight/amdgpu_bl0/brightness
-        ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="amdgpu_bl0", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
+        ACTION=="add", SUBSYSTEM=="backlight", RUN+="${pkgs.coreutils}/bin/chmod a+w /sys/class/backlight/%k/brightness"
       '';
     })
   ];


### PR DESCRIPTION
With simpledrm actually enabled for real this time for sure, the Deck display is amdgpu_bl1. Steam can handle this, we just need to give it permission.