### PR TITLE
wireplumber-sysconf: force order before display-manager.service

### DIFF
--- a/modules/devices/steamdeck/sound.nix
+++ b/modules/devices/steamdeck/sound.nix
@@ -55,6 +55,9 @@ in
     systemd.services.wireplumber.environment = lib.mkIf systemWide extraEnv;
     systemd.user.services.wireplumber.environment = lib.mkIf (!systemWide) extraEnv;
 
-    systemd.services.wireplumber-sysconf.wantedBy = ["multi-user.target"];
+    systemd.services.wireplumber-sysconf = {
+      wantedBy = ["multi-user.target"];
+      before = ["display-manager.service"];
+    };
   };
 }


### PR DESCRIPTION
Requires https://github.com/NixOS/nixpkgs/pull/298363 to actually work with the intended Jovian setup