### PR TITLE
steam/autostart: ensmoothen Plymouth

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1714076141,
-        "narHash": "sha256-Drmja/f5MRHZCskS6mvzFqxEaZMeciScCTFxWVLqWEY=",
+        "lastModified": 1715787315,
+        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7bb2ccd8cdc44c91edba16c48d2c8f331fb3d856",
+        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
         "type": "github"
       },
       "original": {

--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -116,17 +116,17 @@ in
         enable = true;
         settings = {
           default_session = {
-            user = "jovian-greeter";
+            user = "root";
             command = "${pkgs.jovian-greeter}/bin/jovian-greeter ${cfg.user}";
           };
         };
+        greeterManagesPlymouth = true;
       };
 
-      users.users.jovian-greeter = {
-        isSystemUser = true;
-        group = "jovian-greeter";
-      };
-      users.groups.jovian-greeter = {};
+      # We handle this ourselves in the greeter
+      systemd.services.plymouth-quit.enable = false;
+      # Remove multi-user.target dependency on plymouth-quit-wait
+      systemd.services.plymouth-quit-wait.wantedBy = lib.mkForce [];
 
       security.pam.services = {
         greetd.text = ''

--- a/pkgs/jovian-greeter/default.nix
+++ b/pkgs/jovian-greeter/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, python3, shellcheck, nodePackages }:
+{ lib, stdenv, python3, plymouth, shellcheck, nodePackages }:
 
 stdenv.mkDerivation {
   name = "jovian-greeter";
@@ -29,7 +29,7 @@ stdenv.mkDerivation {
     runHook preInstall
 
     install -Dm555 greeter.py $out/bin/jovian-greeter
-    wrapPythonPrograms
+    wrapPythonPrograms --prefix PATH : ${lib.makeBinPath [ plymouth ]}
 
     install -Dm555 ./consume-session $helper/lib/jovian-greeter/consume-session
 

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -85,6 +85,11 @@ class GreetdClient:
         raise RuntimeError('Bad response', response)
 
     def start_session(self, command: List[str], environment: List[str]):
+        try:
+            subprocess.check_call(["plymouth", "quit", "--retain-splash", "--wait"])
+        except Exception as ex:
+            logging.debug("Failed to stop Plymouth", exc_info=ex)
+
         # greetd before 0.9.0 doesn't support env
         command_with_env = [ 'systemd-cat', '--identifier=jovian-session', '--', '/usr/bin/env' ] + environment + command
 

--- a/support/docs/lib/overlay-doc.nix
+++ b/support/docs/lib/overlay-doc.nix
@@ -65,7 +65,11 @@ let
     // (if drv ? version then { inherit (drv) version; } else { version = getVersion drv; })
     // optionalAttrs (drv ? meta.description)      { inherit (drv.meta) description; }
     // optionalAttrs (drv ? meta.longDescription)  { inherit (drv.meta) longDescription; }
-    // optionalAttrs (drv ? meta.license)          { inherit (drv.meta) license; }
+    // optionalAttrs (drv ? meta.license)          { 
+      license = if builtins.isList drv.meta.license 
+                then builtins.head drv.meta.license
+                else drv.meta.license;
+    }
   ;
   overlayData =
     mapAttrs (

--- a/support/manifest/mappings.toml
+++ b/support/manifest/mappings.toml
@@ -173,6 +173,9 @@ libdrm = { map = true, pkgrel = 1 }
 # DisplayLink stuff
 libevdi.ignore = true
 
+# some internal tooling, not shipped
+libversion.ignore = true
+
 # some mainline kernel build
 linux.ignore = true
 
@@ -240,6 +243,9 @@ podman.ignore = true
 
 # we're tracking our fork but want to merge stuff into it
 powerbuttond.check = "2-1"
+
+# some internal tooling, not shipped
+python-libversion.ignore = true
 
 # more A/B stuff
 rauc.ignore = true


### PR DESCRIPTION
Before:

- boot starts
- Plymouth is shown
- Plymouth is shut down (due to greetd being ordered after plymouth-quit-wait)
- greetd starts
- session starts
- session takes over display

Now:

- boot starts
- Plymouth is shown
- greetd starts
- session starts
- Plymouth is shut down (because we tell it to)
- session takes over display

There's still a little bit of black screen in between, but it's a lot better.
