### PR TITLE
steamos-manager: init, wire up

### DIFF
--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -49,9 +49,9 @@ in
       hardware.pulseaudio.support32Bit = true;
       hardware.steam-hardware.enable = mkDefault true;
 
-      environment.systemPackages = [ pkgs.gamescope-session pkgs.steamos-polkit-helpers ];
+      environment.systemPackages = [ pkgs.gamescope-session pkgs.steamos-polkit-helpers pkgs.steamos-manager ];
 
-      systemd.packages = [ pkgs.gamescope-session ];
+      systemd.packages = [ pkgs.gamescope-session pkgs.steamos-manager ];
 
       # Vendor patch: https://raw.githubusercontent.com/Jovian-Experiments/PKGBUILDs-mirror/cdaeca26642d59fc9109e98ac9ce2efe5261df1b/0001-Add-systemd-service.patch
       systemd.user.services.wakehook = {
@@ -62,6 +62,13 @@ in
           Restart = "always";
         };
       };
+
+      systemd.user.services.steamos-manager = {
+        overrideStrategy = "asDropin";
+        wantedBy = [ "gamescope-session.service" ];
+      };
+
+      services.dbus.packages = [ pkgs.steamos-manager ];
 
       services.displayManager.sessionPackages = [ pkgs.gamescope-session ];
 

--- a/overlay.nix
+++ b/overlay.nix
@@ -50,6 +50,7 @@ rec {
   steamdeck-firmware = final.callPackage ./pkgs/jupiter-hw-support/firmware.nix { };
   steamdeck-bios-fwupd = final.callPackage ./pkgs/jupiter-hw-support/bios-fwupd.nix { };
   jupiter-dock-updater-bin = final.callPackage ./pkgs/jupiter-dock-updater-bin { };
+  steamos-manager = final.callPackage ./pkgs/steamos-manager { };
   steamos-polkit-helpers = final.callPackage ./pkgs/jupiter-hw-support/polkit-helpers.nix { };
   steamdeck-dsp = final.callPackage ./pkgs/steamdeck-dsp { };
   wireplumber-jupiter = import ./pkgs/wireplumber {

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -8,13 +8,13 @@
 
 stdenv.mkDerivation rec {
   pname = "jupiter-hw-support-source";
-  version = "20240524.2";
+  version = "20240529.1";
 
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";
     repo = "jupiter-hw-support";
     rev = "jupiter-${version}";
-    hash = "sha256-JBgyn+b5rYEYaPUMic3POI4jn78xfahZvE5HfnY5vsM=";
+    hash = "sha256-YulvDEKUG46wk6xRHY/fWtTF2exIZXbqgHUXf48+1do=";
   };
 
   patches = [

--- a/pkgs/steamos-manager/default.nix
+++ b/pkgs/steamos-manager/default.nix
@@ -1,0 +1,56 @@
+{
+  rustPlatform,
+  fetchFromGitHub,
+  substituteAll,
+  jupiter-hw-support,
+  jovian-stubs,
+  steamos-polkit-helpers,
+  steamdeck-firmware,
+  jupiter-dock-updater-bin,
+}:
+rustPlatform.buildRustPackage rec {
+  pname = "steamos-manager";
+  version = "24.5.1";
+
+  src = fetchFromGitHub {
+    owner = "Jovian-Experiments";
+    repo = "steamos-manager";
+    rev = "v${version}";
+    hash = "sha256-AU3yws5ENrA4flknfbJXp/t9RtkZOaCmrAZ4Bc4uvro=";
+  };
+
+  cargoHash = "sha256-HHzQP12/t86OBR1X0JlhmlWDPcBcvjYykh8VPXni9YQ=";
+
+  # tests assume Steam Deck hardware
+  doCheck = false;
+
+  patches = [ 
+    (substituteAll {
+      src = ./hardcode-paths.patch;
+      hwsupport = jupiter-hw-support;
+      stubs = jovian-stubs;
+      polkitHelpers = steamos-polkit-helpers;
+      steamDeckFirmware = steamdeck-firmware;
+      jupiterDockUpdaterBin = jupiter-dock-updater-bin;
+    })
+    # FIXME: build steamos-log-submitter and reenable this maybe?
+    ./disable-ftrace.patch
+  ];
+
+  postInstall = ''
+    substituteInPlace data/*/*.service --replace-fail "/usr/lib" "$out/bin"
+
+    install -d -m0755 "$out/share/dbus-1/services/"
+    install -d -m0755 "$out/share/dbus-1/system-services/"
+    install -d -m0755 "$out/share/dbus-1/system.d/"
+    install -d -m0755 "$out/lib/systemd/system/"
+    install -d -m0755 "$out/lib/systemd/user/"
+
+    install -m644 "data/system/com.steampowered.SteamOSManager1.service" "$out/share/dbus-1/system-services/"
+    install -m644 "data/system/com.steampowered.SteamOSManager1.conf" "$out/share/dbus-1/system.d/"
+    install -m644 "data/system/steamos-manager.service" "$out/lib/systemd/system/"
+
+    install -m644 "data/user/com.steampowered.SteamOSManager1.service" "$out/share/dbus-1/services/"
+    install -m644 "data/user/steamos-manager.service" "$out/lib/systemd/user/"
+  '';
+}

--- a/pkgs/steamos-manager/disable-ftrace.patch
+++ b/pkgs/steamos-manager/disable-ftrace.patch
@@ -1,0 +1,15 @@
+diff --git a/src/daemon/root.rs b/src/daemon/root.rs
+index a950833..f19e109 100644
+--- a/src/daemon/root.rs
++++ b/src/daemon/root.rs
+@@ -47,8 +47,8 @@ pub async fn daemon() -> Result<()> {
+     };
+     let mut daemon = Daemon::new(subscriber, connection.clone()).await?;
+
+-    let ftrace = Ftrace::init(connection.clone()).await?;
+-    daemon.add_service(ftrace);
++    // let ftrace = Ftrace::init(connection.clone()).await?;
++    // daemon.add_service(ftrace);
+
+     let inhibitor = Inhibitor::init().await?;
+     daemon.add_service(inhibitor);

--- a/pkgs/steamos-manager/hardcode-paths.patch
+++ b/pkgs/steamos-manager/hardcode-paths.patch
@@ -1,0 +1,71 @@
+diff --git a/src/hardware.rs b/src/hardware.rs
+index 09f8dc8..7b443c4 100644
+--- a/src/hardware.rs
++++ b/src/hardware.rs
+@@ -118,7 +118,7 @@ pub(crate) async fn variant() -> Result<HardwareVariant> {
+ pub(crate) async fn check_support() -> Result<HardwareCurrentlySupported> {
+     // Run jupiter-check-support note this script does exit 1 for "Support: No" case
+     // so no need to parse output, etc.
+-    let res = script_exit_code("/usr/bin/jupiter-check-support", &[] as &[String; 0]).await?;
++    let res = script_exit_code("@hwsupport@/bin/jupiter-check-support", &[] as &[String; 0]).await?;
+ 
+     Ok(match res {
+         0 => HardwareCurrentlySupported::Supported,
+diff --git a/src/manager/root.rs b/src/manager/root.rs
+index 6d945fe..4a440c9 100644
+--- a/src/manager/root.rs
++++ b/src/manager/root.rs
+@@ -60,7 +60,7 @@ const ALS_INTEGRATION_PATH: &str = "/sys/devices/platform/AMDI0010:00/i2c-0/i2c-
+ impl SteamOSManager {
+     async fn prepare_factory_reset(&self) -> u32 {
+         // Run steamos factory reset script and return true on success
+-        let res = run_script("/usr/bin/steamos-factory-reset-config", &[""]).await;
++        let res = run_script("@stubs@/bin/steamos-factory-reset-config", &[""]).await;
+         match res {
+             Ok(_) => PrepareFactoryReset::RebootRequired as u32,
+             Err(_) => PrepareFactoryReset::Unknown as u32,
+@@ -120,7 +120,7 @@ impl SteamOSManager {
+     async fn als_calibration_gain(&self) -> f64 {
+         // Run script to get calibration value
+         let result = script_output(
+-            "/usr/bin/steamos-polkit-helpers/jupiter-get-als-gain",
++            "@polkitHelpers@/bin/steamos-polkit-helpers/jupiter-get-als-gain",
+             &[] as &[String; 0],
+         )
+         .await;
+@@ -148,7 +148,7 @@ impl SteamOSManager {
+     async fn update_bios(&mut self) -> fdo::Result<zbus::zvariant::OwnedObjectPath> {
+         // Update the bios as needed
+         self.process_manager
+-            .get_command_object_path("/usr/bin/jupiter-biosupdate", &["--auto"], "updating BIOS")
++            .get_command_object_path("@steamDeckFirmware@/bin/jupiter-biosupdate", &["--auto"], "updating BIOS")
+             .await
+     }
+ 
+@@ -156,7 +156,7 @@ impl SteamOSManager {
+         // Update the dock firmware as needed
+         self.process_manager
+             .get_command_object_path(
+-                "/usr/lib/jupiter-dock-updater/jupiter-dock-updater.sh",
++                "@jupiterDockUpdaterBin@/jupiter-dock-updater/jupiter-dock-updater.sh",
+                 &[] as &[String; 0],
+                 "updating dock",
+             )
+@@ -167,7 +167,7 @@ impl SteamOSManager {
+         // Run steamos-trim-devices script
+         self.process_manager
+             .get_command_object_path(
+-                "/usr/lib/hwsupport/trim-devices.sh",
++                "@hwsupport@/lib/hwsupport/trim-devices.sh",
+                 &[] as &[String; 0],
+                 "trimming devices",
+             )
+@@ -186,7 +186,7 @@ impl SteamOSManager {
+         }
+         self.process_manager
+             .get_command_object_path(
+-                "/usr/lib/hwsupport/format-device.sh",
++                "@hwsupport@/lib/hwsupport/format-device.sh",
+                 args.as_ref(),
+                 format!("formatting {device}").as_str(),
+             )

--- a/support/manifest/mappings.toml
+++ b/support/manifest/mappings.toml
@@ -32,7 +32,7 @@ alsa-ucm-conf.check = "1.2.9-1.2"
 atomupd-daemon-git.ignore = true
 
 # FIXME: has some not-yet-upstream patches, maybe we want them in nixpkgs?
-bluez.check = "5.73-9"
+bluez.check = "5.76-1.1"
 
 # more A/B stuff
 bmap-tools.ignore = true


### PR DESCRIPTION
Currently seems to only use one method, SetWifiDebugMode, which we don't even support.