### PR TITLE
Feature: more/better logging for `greeter.py`, and more reliability

### DIFF
--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -87,6 +87,9 @@ class GreetdClient:
     def start_session(self, command: List[str], environment: List[str]):
         try:
             subprocess.check_call(["plymouth", "quit", "--retain-splash", "--wait"])
+        except FileNotFoundError:
+            logging.debug("Failed to stop Plymouth: could not find executable")
+            logging.debug("If you are not using Plymouth, this failure is benign and expected")
         except Exception as ex:
             logging.debug("Failed to stop Plymouth", exc_info=ex)
 
@@ -122,7 +125,9 @@ class GreetdClient:
 class Context:
     def __init__(self, user: str, home: Path):
         self.user = user
+        logging.debug("USER: {}".format(self.user))
         self.home = home
+        logging.debug("HOME: {}".format(self.home))
         self.xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', '').split(':')
         logging.debug("XDG_DATA_DIRS: {}".format(self.xdg_data_dirs))
 
@@ -151,7 +156,7 @@ class Context:
             stderr = res.stderr.decode('utf-8').strip()
             if stderr == "":
                 stderr = "<no STDERR found>"
-            logging.debug('STDERR: {}'.format(stderr))
+            logging.debug('STDERR for `consume-session`: {}'.format(stderr))
 
             if not next_session:
                 return None

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -124,6 +124,7 @@ class Context:
         self.user = user
         self.home = home
         self.xdg_data_dirs = os.environ.get('XDG_DATA_DIRS', '').split(':')
+        logging.debug("XDG_DATA_DIRS: {}".format(self.xdg_data_dirs))
 
     def next_session(self) -> Optional[Session]:
         sessions = [ DEFAULT_SESSION ]

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -147,7 +147,10 @@ class Context:
                 env={'SHELL': '/bin/sh'}
             )
             next_session = res.stdout.decode('utf-8').strip()
-            logging.debug('STDERR: {}'.format(res.stderr.decode('utf-8').strip()))
+            stderr = res.stderr.decode('utf-8').strip()
+            if stderr == "":
+                stderr = "<no STDERR found>"
+            logging.debug('STDERR: {}'.format(stderr))
 
             if not next_session:
                 return None
@@ -177,9 +180,11 @@ class Context:
                 wayland_session = data_dir.joinpath('wayland-sessions').joinpath(desktop_file)
                 x_session = data_dir.joinpath('xsessions').joinpath(desktop_file)
 
+                logging.debug("Checking wayland session path: {}".format(wayland_session))
                 if wayland_session.exists():
                     return WaylandSession(session, wayland_session)
 
+                logging.debug("Checking X session path: {}".format(x_session))
                 if x_session.exists():
                     return XSession(session, x_session)
 

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -137,6 +137,7 @@ class Context:
         helper = HELPER_PREFIX.joinpath('consume-session')
         if helper.exists():
             logging.debug('Using pkexec helper')
+            logging.debug('Helper path: {}'.format(helper))
             res = subprocess.run(
                 ['/run/wrappers/bin/pkexec', helper, self.user],
                 stdin=subprocess.DEVNULL,
@@ -145,6 +146,7 @@ class Context:
                 env={'SHELL': '/bin/sh'}
             )
             next_session = res.stdout.decode('utf-8').strip()
+            logging.debug('STDERR: {}'.format(res.stderr.decode('utf-8').strip()))
 
             if not next_session:
                 return None

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -172,7 +172,7 @@ class Context:
         return next_session
 
     def _find_sessions(self, sessions: Iterable[str]) -> Optional[Session]:
-        for data_dir in self.xdg_data_dirs + [ '/usr/share' ]:
+        for data_dir in self.xdg_data_dirs + [ '/usr/share', '/run/current-system/sw/share/xsessions/' ]:
             data_dir = Path(data_dir)
             for session in sessions:
                 logging.debug("Examining session: {}".format(session))

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -127,6 +127,7 @@ class Context:
 
     def next_session(self) -> Optional[Session]:
         sessions = [ DEFAULT_SESSION ]
+        logging.debug("Sessions: {}".format(sessions))
 
         if next_session := self._consume_session():
             sessions = [ next_session ] + sessions
@@ -171,6 +172,7 @@ class Context:
         for data_dir in self.xdg_data_dirs + [ '/usr/share' ]:
             data_dir = Path(data_dir)
             for session in sessions:
+                logging.debug("Examining session: {}".format(session))
                 desktop_file = f'{session}.desktop'
                 wayland_session = data_dir.joinpath('wayland-sessions').joinpath(desktop_file)
                 x_session = data_dir.joinpath('xsessions').joinpath(desktop_file)

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -172,7 +172,7 @@ class Context:
         return next_session
 
     def _find_sessions(self, sessions: Iterable[str]) -> Optional[Session]:
-        for data_dir in self.xdg_data_dirs + [ '/usr/share', '/run/current-system/sw/share/xsessions/' ]:
+        for data_dir in self.xdg_data_dirs + [ '/usr/share', '/run/current-system/sw/share' ]:
             data_dir = Path(data_dir)
             for session in sessions:
                 logging.debug("Examining session: {}".format(session))
@@ -180,7 +180,7 @@ class Context:
                 wayland_session = data_dir.joinpath('wayland-sessions').joinpath(desktop_file)
                 x_session = data_dir.joinpath('xsessions').joinpath(desktop_file)
 
-                logging.debug("Checking wayland session path: {}".format(wayland_session))
+                logging.debug("Checking Wayland session path: {}".format(wayland_session))
                 if wayland_session.exists():
                     return WaylandSession(session, wayland_session)
 


### PR DESCRIPTION
Changes:
- More logs (in the interest of debugging misconfigurations & other issues -- it prints environment variable context, specific paths being checked during early business logic, etc)

- Explicitly checks under `/run/current-system/sw/share/` for `xsessions` and `wayland-sessions`.

- Replace the scary-looking tracelog dump for `plymouth` executable being missing with a specific, concise error message that explicitly indicates it is not a serious failure mode. (I saw some confusion surrounding this issue.)

Closes #368