### PR TITLE
jovian-install-iso: init

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723991338,
-        "narHash": "sha256-Grh5PF0+gootJfOJFenTTxDTYPidA3V28dqJ/WV7iis=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8a3354191c0d7144db9756a74755672387b702ba",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,10 @@
   in {
     legacyPackages = eachSupportedSystem (pkgs: pkgs);
 
+    packages = eachSupportedSystem (pkgs: {
+      jovian-install-iso = (pkgs.nixos ./support/install-iso/configuration.nix).config.system.build.isoImage;
+    });
+
     nixosModules = rec {
       default = jovian;
       jovian = ./modules;

--- a/support/install-iso/configuration.nix
+++ b/support/install-iso/configuration.nix
@@ -1,0 +1,31 @@
+{ lib, modulesPath, pkgs, ... }:
+
+{
+  imports = [
+    # we don't want to pull in Calamares, as it's not Jovian-aware
+    (modulesPath + "/installer/cd-dvd/installation-cd-graphical-base.nix")
+    ../../modules
+  ];
+
+  config = {
+    services.desktopManager.plasma6.enable = true;
+
+    # Automatically login as nixos.
+    services.displayManager = {
+      sddm.enable = true;
+      autoLogin = {
+        enable = true;
+        user = "nixos";
+      };
+    };
+
+    environment.systemPackages = [
+      # FIXME: using Qt5 builds of Maliit as upstream has not ported to Qt6 yet
+      pkgs.maliit-framework
+      pkgs.maliit-keyboard
+    ];
+
+    jovian.devices.steamdeck.enable = true;
+    hardware.pulseaudio.enable = lib.mkForce false;
+  };
+}


### PR DESCRIPTION
OLED users can't get network on the default installer, so build our own, slightly Deck flavored one.