### PR TITLE
jovian-steam-protocol-handler: simplify

### DIFF
--- a/pkgs/jovian-steam-protocol-handler/default.nix
+++ b/pkgs/jovian-steam-protocol-handler/default.nix
@@ -1,9 +1,8 @@
 {
-  writeShellScript,
   steamPackages,
 }:
 # FIXME: this is a hack, replace with a better implementation
 # Investigate magic socket?
-writeShellScript "jovian-steam-protocol-handler" ''
-  exec ${steamPackages.steam-fhsenv.run}/bin/steam-run ~/.steam/root/ubuntu12_32/steam "$@"
-''
+steamPackages.steam-fhsenv.overrideAttrs(old: {
+  runScript = "~/.steam/root/ubuntu12_32/steam";
+})

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,4 +1,5 @@
 { 
+  lib,
   stdenv, 
   fetchFromGitHub, 
   substituteAll, 
@@ -19,7 +20,7 @@ stdenv.mkDerivation rec {
 
   patches = [
     (substituteAll {
-      handler = jovian-steam-protocol-handler;
+      handler = lib.getExe jovian-steam-protocol-handler;
       systemd = systemd;
       src = ./jovian.patch;
     })

--- a/pkgs/powerbuttond/default.nix
+++ b/pkgs/powerbuttond/default.nix
@@ -20,7 +20,7 @@ stdenv.mkDerivation {
 
   patches = [
     (substituteAll {
-      handler = jovian-steam-protocol-handler;
+      handler = lib.getExe jovian-steam-protocol-handler;
       src = ./jovian.patch;
     })
   ];

--- a/pkgs/steam_notif_daemon/default.nix
+++ b/pkgs/steam_notif_daemon/default.nix
@@ -23,7 +23,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   patches = [
     (substituteAll {
-      handler = jovian-steam-protocol-handler;
+      handler = lib.getExe jovian-steam-protocol-handler;
       src = ./jovian.patch;
     })
   ];


### PR DESCRIPTION
Instead of going through steam-run, just override the Steam fhsenv directly to run the right thing with no extra steps.