### PR TITLE
steamdeck: Enable automount

### DIFF
--- a/modules/devices/steamdeck/hw-support.nix
+++ b/modules/devices/steamdeck/hw-support.nix
@@ -14,6 +14,14 @@ in
 {
   options = {
     jovian.devices.steamdeck = {
+      enableAutoMountUdevRules = mkOption {
+        default = cfg.enable;
+        defaultText = lib.literalExpression "config.jovian.devices.steamdeck.enable";
+        type = types.bool;
+        description = ''
+          Whether to enable udev rules to automatically mount SD cards upon insertion.
+        '';
+      };
       enableDefaultCmdlineConfig = mkOption {
         default = cfg.enable;
         defaultText = lib.literalExpression "config.jovian.devices.steamdeck.enable";
@@ -34,6 +42,11 @@ in
   };
 
   config = mkMerge [
+    (mkIf (cfg.enableAutoMountUdevRules) {
+      services.udev.packages = [
+        pkgs.jupiter-hw-support
+      ];
+    })
     (mkIf (cfg.enableDefaultStage1Modules) {
       boot.initrd.kernelModules = [
         "hid-generic"

--- a/modules/devices/steamdeck/hw-support.nix
+++ b/modules/devices/steamdeck/hw-support.nix
@@ -14,14 +14,6 @@ in
 {
   options = {
     jovian.devices.steamdeck = {
-      enableAutoMountUdevRules = mkOption {
-        default = cfg.enable;
-        defaultText = lib.literalExpression "config.jovian.devices.steamdeck.enable";
-        type = types.bool;
-        description = ''
-          Whether to enable udev rules to automatically mount SD cards upon insertion.
-        '';
-      };
       enableDefaultCmdlineConfig = mkOption {
         default = cfg.enable;
         defaultText = lib.literalExpression "config.jovian.devices.steamdeck.enable";
@@ -42,11 +34,6 @@ in
   };
 
   config = mkMerge [
-    (mkIf (cfg.enableAutoMountUdevRules) {
-      services.udev.packages = [
-        pkgs.jupiter-hw-support
-      ];
-    })
     (mkIf (cfg.enableDefaultStage1Modules) {
       boot.initrd.kernelModules = [
         "hid-generic"

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -104,7 +104,7 @@ in
         # We don't support adopting a drive, yet.
         STEAM_ALLOW_DRIVE_ADOPT = mkDefault "0";
         # Ejecting doesn't work, either.
-        STEAM_ALLOW_DRIVE_UNMOUNT = mkDefault "0";
+        STEAM_ALLOW_DRIVE_UNMOUNT = mkDefault "1";
       };
     }
   ]);

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -68,6 +68,14 @@ in
         wantedBy = [ "gamescope-session.service" ];
       };
 
+      systemd.services.steamos-manager = {
+        overrideStrategy = "asDropin";
+        path = [
+          # .../lib/hwsupport/format-device.sh makes an unqualified `umount` call.
+          "/run/wrappers/"
+        ];
+      };
+
       services.dbus.packages = [ pkgs.steamos-manager ];
 
       services.displayManager.sessionPackages = [ pkgs.gamescope-session ];

--- a/modules/steamos/automount.nix
+++ b/modules/steamos/automount.nix
@@ -1,0 +1,32 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  cfg = config.jovian.steamos;
+in
+{
+  options = {
+    jovian.steamos = {
+      enableAutoMountUdevRules = mkOption {
+        default = cfg.useSteamOSConfig;
+        defaultText = lib.literalExpression "config.jovian.steamos.useSteamOSConfig";
+        type = types.bool;
+        description = ''
+          Whether to enable udev rules to automatically mount SD cards upon insertion.
+        '';
+      };
+    };
+  };
+  config = mkMerge [
+    (mkIf (cfg.enableAutoMountUdevRules) {
+      services.udev.packages = [
+        pkgs.jupiter-hw-support
+      ];
+    })
+  ];
+}

--- a/modules/steamos/default.nix
+++ b/modules/steamos/default.nix
@@ -8,6 +8,7 @@ let
 in
 {
   imports = [
+    ./automount.nix
     ./bluetooth.nix
     ./boot.nix
     ./mesa.nix

--- a/pkgs/jupiter-hw-support/0001-Jovian-Ensure-automounting-works-for-any-UID-1000-us.patch
+++ b/pkgs/jupiter-hw-support/0001-Jovian-Ensure-automounting-works-for-any-UID-1000-us.patch
@@ -1,0 +1,45 @@
+From 42798ed60fbc601cefab84fd1f2c8dab95906702 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 29 Sep 2024 02:52:26 -0400
+Subject: [PATCH] =?UTF-8?q?[Jovian]=C2=A0Ensure=20automounting=20works=20f?=
+ =?UTF-8?q?or=20any=20UID=201000=20username?=
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ usr/lib/hwsupport/steamos-automount.sh | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/usr/lib/hwsupport/steamos-automount.sh b/usr/lib/hwsupport/steamos-automount.sh
+index 386f4d8..8583ca7 100755
+--- a/usr/lib/hwsupport/steamos-automount.sh
++++ b/usr/lib/hwsupport/steamos-automount.sh
+@@ -22,8 +22,12 @@ fi
+ ACTION=$1
+ DEVBASE=$2
+ DEVICE="/dev/${DEVBASE}"
+-DECK_UID=$(id -u deck)
+-DECK_GID=$(id -g deck)
++# Jovian Experiments assumptions:
++#  - UID for Steam user is 1000
++#  - Username is unknown
++DECK_UID=1000
++DECK_GID=$(id -g "$DECK_UID")
++DECK_USERNAME=$(id -nu "$DECK_UID")
+ 
+ send_steam_url()
+ {
+@@ -90,7 +94,7 @@ do_mount()
+                                  "block_devices/${DEVBASE}"      \
+                                  Filesystem Mount                \
+                                  'a{sv}' 3                       \
+-                                 as-user s deck                  \
++                                 as-user s "$DECK_USERNAME"      \
+                                  auth.no_user_interaction b true \
+                                  options s "$OPTS")
+ 
+-- 
+2.46.0
+

--- a/pkgs/jupiter-hw-support/0001-format-device-Harden-against-mountpoint-being-listed.patch
+++ b/pkgs/jupiter-hw-support/0001-format-device-Harden-against-mountpoint-being-listed.patch
@@ -1,0 +1,30 @@
+From eee1d1e1f8e6d7a2246e3428d71522e02b04c5d7 Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 29 Sep 2024 21:45:49 -0400
+Subject: [PATCH] format-device: Harden against mountpoint being listed more
+ than once
+
+This can happen with some combination of bind mounts magic, where the
+mount point may appear at more than one location at a time.
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ usr/lib/hwsupport/format-device.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/usr/lib/hwsupport/format-device.sh b/usr/lib/hwsupport/format-device.sh
+index 65d77f8..0400ae8 100755
+--- a/usr/lib/hwsupport/format-device.sh
++++ b/usr/lib/hwsupport/format-device.sh
+@@ -77,6 +77,8 @@ fi
+ # If any partitions on the device are mounted, unmount them before continuing
+ # to prevent problems later
+ lsblk -n "$STORAGE_DEVICE" -o MOUNTPOINTS | awk NF | sort -u | while read m; do
++    # Check the mountpoint still exists, in case the mount point is reported more than once.
++    test -e "$m" || continue
+     if ! umount "$m"; then
+         echo "Failed to unmount filesystem: $m"
+         exit 32 # EPIPE
+-- 
+2.46.0
+

--- a/pkgs/jupiter-hw-support/0001-steamos-automount-Harden-against-missing-run-media.patch
+++ b/pkgs/jupiter-hw-support/0001-steamos-automount-Harden-against-missing-run-media.patch
@@ -1,0 +1,36 @@
+From 55674111fe7956adb41c2b8d0c6fbb3c3d6ca8bf Mon Sep 17 00:00:00 2001
+From: Samuel Dionne-Riel <samuel@dionne-riel.com>
+Date: Sun, 29 Sep 2024 02:36:41 -0400
+Subject: [PATCH] steamos-automount: Harden against missing /run/media
+
+When running against some systems, it is possible `/run/media` does not
+exist when trying to unmount a path. E.g. with `UDISKS_FILESYSTEM_SHARED`.
+
+Signed-off-by: Samuel Dionne-Riel <samuel@dionne-riel.com>
+---
+ usr/lib/hwsupport/steamos-automount.sh | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/usr/lib/hwsupport/steamos-automount.sh b/usr/lib/hwsupport/steamos-automount.sh
+index 8583ca7..0b0457f 100755
+--- a/usr/lib/hwsupport/steamos-automount.sh
++++ b/usr/lib/hwsupport/steamos-automount.sh
+@@ -107,6 +107,7 @@ do_mount()
+     # that use the older mount point (for SD cards only).
+     case "${DEVBASE}" in
+         mmcblk0p*)
++            mkdir -p /run/media
+             if [[ -z "${ID_FS_LABEL}" ]]; then
+                 old_mount_point="/run/media/${DEVBASE}"
+             else
+@@ -124,6 +125,7 @@ do_mount()
+ 
+ do_unmount()
+ {
++    mkdir -p /run/media
+     local mount_point=$(findmnt -fno TARGET "${DEVICE}" || true)
+     if [[ -n $mount_point ]]; then
+         # Remove symlink to the mount point that we're unmounting
+-- 
+2.46.0
+

--- a/pkgs/jupiter-hw-support/automount-fix-system-paths.patch
+++ b/pkgs/jupiter-hw-support/automount-fix-system-paths.patch
@@ -2,18 +2,6 @@ diff --git a/usr/lib/hwsupport/steamos-automount.sh b/usr/lib/hwsupport/steamos-
 index 386f4d8..cf79351 100755
 --- a/usr/lib/hwsupport/steamos-automount.sh
 +++ b/usr/lib/hwsupport/steamos-automount.sh
-@@ -22,8 +22,9 @@ fi
- ACTION=$1
- DEVBASE=$2
- DEVICE="/dev/${DEVBASE}"
--DECK_UID=$(id -u deck)
--DECK_GID=$(id -g deck)
-+# Jovian: hardcode these for now
-+DECK_UID=1000
-+DECK_GID=100
- 
- send_steam_url()
- {
 @@ -33,7 +34,7 @@ send_steam_url()
    if pgrep -x "steam" > /dev/null; then
        # TODO use -ifrunning and check return value - if there was a steam process and it returns -1, the message wasn't sent

--- a/pkgs/jupiter-hw-support/default.nix
+++ b/pkgs/jupiter-hw-support/default.nix
@@ -22,7 +22,7 @@ let
   src = callPackage ./src.nix { };
 
   solution = {
-    scripts = [ "bin/*" "lib/hwsupport/*.sh" ];
+    scripts = [ "bin/*" "lib/hwsupport/*.sh" "lib/hwsupport/common-functions" ];
     interpreter = "${bash}/bin/bash";
     inputs = [
       coreutils
@@ -89,6 +89,12 @@ stdenv.mkDerivation {
 
     substituteInPlace $out/lib/hwsupport/* \
       --replace-warn ". /usr/lib/hwsupport" ". $out/lib/hwsupport"
+
+    mkdir -p $out/lib/udev/rules.d
+
+    substitute usr/lib/udev/rules.d/99-steamos-automount.rules $out/lib/udev/rules.d/99-steamos-automount.rules \
+      --replace-warn "/bin/systemd-run" "${systemd}/bin/systemd-run" \
+      --replace-warn "/usr/lib/hwsupport" "$out/lib/hwsupport"
 
     ${resholve.phraseSolution "jupiter-hw-support" solution}
 

--- a/pkgs/jupiter-hw-support/default.nix
+++ b/pkgs/jupiter-hw-support/default.nix
@@ -91,10 +91,12 @@ stdenv.mkDerivation {
       --replace-warn ". /usr/lib/hwsupport" ". $out/lib/hwsupport"
 
     mkdir -p $out/lib/udev/rules.d
+    cp usr/lib/udev/rules.d/99-steamos-automount.rules $out/lib/udev/rules.d
+    cp usr/lib/udev/rules.d/99-sdcard-rescan.rules $out/lib/udev/rules.d
 
-    substitute usr/lib/udev/rules.d/99-steamos-automount.rules $out/lib/udev/rules.d/99-steamos-automount.rules \
-      --replace-warn "/bin/systemd-run" "${systemd}/bin/systemd-run" \
-      --replace-warn "/usr/lib/hwsupport" "$out/lib/hwsupport"
+    substituteInPlace $out/lib/udev/rules.d/*.rules \
+      --replace-fail "/bin/systemd-run" "${systemd}/bin/systemd-run" \
+      --replace-fail "/usr/lib/hwsupport" "$out/lib/hwsupport"
 
     ${resholve.phraseSolution "jupiter-hw-support" solution}
 

--- a/pkgs/jupiter-hw-support/default.nix
+++ b/pkgs/jupiter-hw-support/default.nix
@@ -105,11 +105,11 @@ stdenv.mkDerivation {
 
   meta = with lib; {
     description = ''
-      Steam Deck (Jupiter) hardware support package
+      Steam OS's generic “hardware support” package.
 
-      This package only contains the utility scripts as well as UCM files.
-      For the themes as well as unfree firmware, see the `steamdeck-theme`
-      and `steamdeck-firmware` packages.
+      This package contains the hardware-agnostic files from the `jupiter-hw-support` package.
+
+      For themes, as well as unfree firmware, see the `steamdeck-theme` and `steamdeck-firmware` packages.
     '';
     license = licenses.mit;
   };

--- a/pkgs/jupiter-hw-support/polkit-helpers.nix
+++ b/pkgs/jupiter-hw-support/polkit-helpers.nix
@@ -80,7 +80,7 @@ in stdenv.mkDerivation {
   patchPhase = ''
     runHook prePatch
   
-    substituteInPlace usr/share/polkit-1/actions/org.valve.steamos.policy --replace /usr $out
+    substituteInPlace usr/share/polkit-1/actions/org.valve.steamos.policy --replace-fail /usr $out
 
     runHook postPatch
   '';

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -21,7 +21,7 @@ stdenv.mkDerivation rec {
     (substituteAll {
       handler = jovian-steam-protocol-handler;
       systemd = systemd;
-      src = ./jovian.patch;
+      src = ./automount-fix-system-paths.patch;
     })
     # Fix controller updates with python-hid >= 1.0.6
     ./hid-1.0.6.patch

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -27,6 +27,9 @@ stdenv.mkDerivation rec {
     ./hid-1.0.6.patch
     # Remove `deck` username assumption
     ./0001-Jovian-Ensure-automounting-works-for-any-UID-1000-us.patch
+    # Minor fixes against silly environments
+    ./0001-steamos-automount-Harden-against-missing-run-media.patch
+    ./0001-format-device-Harden-against-mountpoint-being-listed.patch
   ];
 
   installPhase = ''

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -25,6 +25,8 @@ stdenv.mkDerivation rec {
     })
     # Fix controller updates with python-hid >= 1.0.6
     ./hid-1.0.6.patch
+    # Remove `deck` username assumption
+    ./0001-Jovian-Ensure-automounting-works-for-any-UID-1000-us.patch
   ];
 
   installPhase = ''


### PR DESCRIPTION
I put it in steamdeck because it depends on `jupiter-hw-support`.