### PR TITLE
Fix decky extraPythonPackages module option

### DIFF
--- a/modules/decky-loader.nix
+++ b/modules/decky-loader.nix
@@ -9,7 +9,7 @@ let
   cfg = config.jovian.decky-loader;
 
   package = cfg.package.overridePythonAttrs(old: {
-    dependencies = old.dependencies ++ (cfg.extraPythonPackages old.python.pkgs);
+    dependencies = old.dependencies ++ (cfg.extraPythonPackages old.passthru.python.pkgs);
   });
 in
 {


### PR DESCRIPTION
Currently, trying to add python packages to decky through the `extraPythonPackages` option causes builds to fail:
```
       error: attribute 'python' missing

       at /nix/store/6jqip5lhi97w238d2carq8q60qas9ba1-source/modules/decky-loader.nix:12:65:

           11|   package = cfg.package.overridePythonAttrs(old: {
           12|     dependencies = old.dependencies ++ (cfg.extraPythonPackages old.python.pkgs);
             |                                                                 ^
           13|   });
```

This PR fixes this.