### PR TITLE
Add support for formatting from the Deck UI

### DIFF
--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -49,7 +49,12 @@ in
       hardware.pulseaudio.support32Bit = true;
       hardware.steam-hardware.enable = mkDefault true;
 
-      environment.systemPackages = [ pkgs.gamescope-session pkgs.steamos-polkit-helpers pkgs.steamos-manager ];
+      environment.systemPackages = [
+        pkgs.gamescope-session
+        pkgs.steamos-polkit-helpers
+        pkgs.steamos-manager
+        pkgs.jovian-support-scripts
+      ];
 
       systemd.packages = [ pkgs.gamescope-session pkgs.steamos-manager ];
 

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -114,9 +114,7 @@ in
       '';
 
       jovian.steam.environment = {
-        # We don't support adopting a drive, yet.
-        STEAM_ALLOW_DRIVE_ADOPT = mkDefault "0";
-        # Ejecting doesn't work, either.
+        STEAM_ALLOW_DRIVE_ADOPT = mkDefault "1";
         STEAM_ALLOW_DRIVE_UNMOUNT = mkDefault "1";
       };
     }

--- a/overlay.nix
+++ b/overlay.nix
@@ -53,6 +53,7 @@ rec {
   jovian-stubs = final.callPackage ./pkgs/jovian-stubs { };
   jovian-greeter = final.callPackage ./pkgs/jovian-greeter { };
   jovian-steam-protocol-handler = final.callPackage ./pkgs/jovian-steam-protocol-handler { };
+  jovian-support-scripts = final.callPackage ./pkgs/jovian-support-scripts { };
 
   jovian-documentation = final.callPackage ./support/docs {
     pagefind = final.callPackage ./pkgs/pagefind { };

--- a/pkgs/jovian-support-scripts/default.nix
+++ b/pkgs/jovian-support-scripts/default.nix
@@ -1,0 +1,49 @@
+{ stdenv
+, resholve
+
+, bash
+, jq
+, systemd
+, util-linux
+}:
+
+let
+  solution = {
+    scripts = [ "bin/steamos-polkit-helpers/*" ];
+    interpreter = "${bash}/bin/bash";
+    inputs = [
+      jq
+      systemd
+      util-linux
+    ];
+    keep = {
+      "${placeholder "out"}/bin/steamos-polkit-helpers/steamos-format-device" = true;
+    };
+  };
+in
+stdenv.mkDerivation {
+  name = "jovian-support-scripts";
+
+  buildCommand = ''
+    install -D -m 755 ${./steamos-format-sdcard} $out/bin/steamos-format-sdcard
+    install -D -m 755 ${./steamos-format-device} $out/bin/steamos-format-device
+
+    substituteInPlace $out/bin/steamos-format-sdcard \
+      --replace-fail "/usr/bin/steamos-polkit-helpers/steamos-format-device" "$out/bin/steamos-polkit-helpers/steamos-format-device"
+    (
+    cd $out/bin
+
+    mkdir -v steamos-polkit-helpers
+    cd steamos-polkit-helpers
+    ln -v -t . ../steamos-format-*
+    )
+
+    ${resholve.phraseSolution "steamos-format-sdcard" solution}
+    ${resholve.phraseSolution "steamos-format-device" solution}
+  '';
+
+  meta = {
+    # Any script defined here should be prioritized over Steam's own.
+    priority = -10;
+  };
+}

--- a/pkgs/jovian-support-scripts/steamos-format-device
+++ b/pkgs/jovian-support-scripts/steamos-format-device
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# [Jovian]
+#
+# Not a polkit helper anymore, this calls the steamos-manager system service
+# to poke through the fhsenv used here.
+#
+# Note that this is uh... quite a hack, but uh... works?
+#
+# The TLDR is:
+#
+#  - We poke the steamos-manager to run the dbus endpoint for formatting
+#  - We `tail` the journal for the output from the script
+#
+# And uh, this fulfills the requirements for Steam (stage=... flags).
+#
+
+cleanup() {
+	 >/dev/null 2>&1 \
+		 kill -9 % || :
+}
+
+trap cleanup EXIT SIGINT SIGTERM
+
+_call() {
+	object="$1"; shift
+	interface="$1"; shift
+	busctl --timeout=99y --expect-reply=yes -j \
+		call \
+		com.steampowered.SteamOSManager1 \
+		"$object" \
+		com.steampowered.SteamOSManager1."${interface}" \
+		"$@" \
+		| jq -r .data[0]
+}
+
+# Only supported flags, from the DBUS interface shape (ssb)
+#  • --skip-validation|--force)
+#  • --device)
+#  • --label)
+
+DEVICE=""
+LABEL="STEAM-$RANDOM"
+VALIDATE="true"
+
+OPTS=$(getopt -l force,skip-validation,device:,label: -n steamos-format-device -- "" "$@")
+
+eval set -- "$OPTS"
+
+while true; do
+	case "$1" in
+		--force)
+			# yes, this is just like --skip-validate in the vendor script
+			VALIDATE="false"
+			shift
+			;;
+		--skip-validation)
+			# yes, this is just like --force in the vendor script
+			VALIDATE="false"
+			shift
+			;;
+		--label)
+			LABEL="$2";
+			shift 2
+			;;
+		--device)
+			DEVICE="$2"
+			shift 2
+			;;
+		--) shift; break ;;
+	esac
+done
+
+if [[ "$DEVICE" == "" ]]; then
+	>&2 printf "Error: --device flag mandatory\n"
+	exit 1
+fi
+
+journalctl --lines=0 --follow \
+	--output cat \
+	--unit steamos-manager.service \
+	SYSLOG_IDENTIFIER=steamos-format-device &
+
+process=$(_call "/com/steampowered/SteamOSManager1" Manager FormatDevice ssb "$DEVICE" "$LABEL" "$VALIDATE")
+res="$(_call "${process}" "SubProcess" Wait)"
+
+exit "$res"

--- a/pkgs/jovian-support-scripts/steamos-format-sdcard
+++ b/pkgs/jovian-support-scripts/steamos-format-sdcard
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eu
+
+# [Jovian]
+# Not a polkit helper anymore, this calls the `format-device` helper following
+# the same semantics as `usr/lib/hwsupport/format-sdcard.sh`.
+
+exec /usr/bin/steamos-polkit-helpers/steamos-format-device \
+	--device /dev/mmcblk0 "$@"

--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -4,6 +4,7 @@
 { writeShellScriptBin
 , dmidecode
 , jovian-stubs
+, jovian-support-scripts
 , steam-fhsenv
 # , steamos-polkit-helpers
 , ...
@@ -16,6 +17,7 @@ let
     "writeShellScriptBin"
     "dmidecode"
     "jovian-stubs"
+    "jovian-support-scripts"
     "steam-fhsenv"
     "steamos-polkit-helpers"
   ];
@@ -47,6 +49,7 @@ let
     extraPkgs = pkgs: (if args ? extraPkgs then args.extraPkgs pkgs else []) ++ [
       dmidecode
       jovian-stubs
+      jovian-support-scripts
       sessionSwitcher
 
       # FIXME: figure out how to fix pkexec (needs SUID in fhsenv, see https://github.com/NixOS/nixpkgs/issues/69338) 


### PR DESCRIPTION
Follow-up to #413. Closes #321.

* * *

This change set implements the formatting script in a way that works under our FHS...

... by using the method *Steam* would end-up using in the future? (Assuming it'll rely on `steamos-manager`.

With this one weird trick the script is doing, it *looks* like the script is actually running, and its output relayed to the parent process (e.g. Steam)... but what's actually happening is through `jourald`, we peek at the output of `steamos-manager.service` (filtering on the syslog identifier)... `steamos-manager` was asked to *do the it* through a simple *dbus* call.

Simply that.

* * *

### Enhancements required

#### Prevent running against block device with mounted storage

On some of Jovian Experiment's users' systems, it's been observed that the block device where the rootfs resides is showing up in Steam as an option to target and attempt to format.

This uh... could lead to *unfun results*... but wasn't tried.

Unsure at which end it should happen, but checks should be made so the script fails early if the block device has any "mounted" partitions (which includes swap too).

### TODO

 - [ ] Prevent running against block device with mounted storage
 - [ ] Test on non-steamdeck [should be fine]
 - [ ] Test with a USB drive