### PR TITLE
decky-loader{,-prerelease}: update pnpm hashes for pnpm 9.12.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690328911,
-        "narHash": "sha256-fxtExYk+aGf2YbjeWQ8JY9/n9dwuEt+ma1eUFzF8Jeo=",
+        "lastModified": 1729697500,
+        "narHash": "sha256-VFTWrbzDlZyFHHb1AlKRiD/qqCJIripXKiCSFS8fAOY=",
         "owner": "zhaofengli",
         "repo": "nix-github-actions",
-        "rev": "96df4a39c52f53cb7098b923224d8ce941b64747",
+        "rev": "e418aeb728b6aa5ca8c5c71974e7159c2df1d8cf",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1728888510,
-        "narHash": "sha256-nsNdSldaAyu6PE3YUA+YQLqUDJh+gRbBooMMekZJwvI=",
+        "lastModified": 1729665710,
+        "narHash": "sha256-AlcmCXJZPIlO5dmFzV3V2XF6x/OpNWUV8Y/FMPGd8Z4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a3c0b3b21515f74fd2665903d4ce6bc4dc81c77c",
+        "rev": "2768c7d042a37de65bb1b5b3268fc987e534c49d",
         "type": "github"
       },
       "original": {

--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -20,7 +20,7 @@ python3.pkgs.buildPythonPackage rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-IX7WI0q30Wa54sSpPQu9SarxijS9BQFgo6Lkw12E6GI=";
+    hash = "sha256-iQjWuD0NhWiGdx6L7sDdHqdHSbkOjqa/0wer1Revvc8=";
   };
 
   pyproject = true;

--- a/pkgs/decky-loader/prerelease.nix
+++ b/pkgs/decky-loader/prerelease.nix
@@ -17,6 +17,6 @@ decky-loader.overridePythonAttrs rec {
   pnpmDeps = pnpm.fetchDeps {
     inherit pname version src;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-MoYNX8jyITR26bfFPYRTsWxILw+LUtmAp714Ch0aYJQ=";
+    hash = "sha256-l4AA3xOdouk08i9n0lWbzeKCTqEkXC0BOsW1uxQMPyo=";
   };
 }


### PR DESCRIPTION
Waiting for it to land in nixos-unstable before merging