### PR TITLE
Make module a no-op by default, and add check for no-op

### DIFF
--- a/.github/workflows/no-op.yml
+++ b/.github/workflows/no-op.yml
@@ -1,0 +1,15 @@
+name: Module No-Op
+on:
+  pull_request:
+  push:
+jobs:
+  eval:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.0.2
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v4
+
+      - name: Verify module is a No-Op
+        run: nix-instantiate ./support/nix-tests/check-no-ops.nix

--- a/modules/steamos/default.nix
+++ b/modules/steamos/default.nix
@@ -1,4 +1,4 @@
-{ lib, ... }:
+{ lib, config, ... }:
 
 let
   inherit (lib)
@@ -19,7 +19,8 @@ in
     jovian.steamos = {
       useSteamOSConfig = mkOption {
         type = types.bool;
-        default = true;
+        default = config.jovian.steam.enable;
+        defaultText = "config.jovian.steam.enable";
         description = ''
           Whether to enable opinionated system configuration from SteamOS.
 

--- a/support/nix-tests/check-no-ops.nix
+++ b/support/nix-tests/check-no-ops.nix
@@ -1,0 +1,50 @@
+#!/usr/bin/env nix-instantiate
+#
+# SPDX-License-Identifier: MIT
+#
+# Author: Samuel Dionne-Riel
+#
+# What's this? A shebang and +x in my Nix expression??
+# ¯\_(ツ)_/¯
+#
+# Test that eval for unconfigured modules are no-ops.
+#
+# Origin: https://gitlab.com/samueldr/nixos-configuration/-/blob/cb5c6a1671ebeb1250e4f00e89787f15f45a37f1/modules/tests/check-no-ops.nix
+#
+
+let nixpkgs = ../../nixpkgs.nix; in
+{ pkgs ? import nixpkgs {} }:
+
+let
+  baseCfg = {
+    # Prevent stray warnings
+    system.stateVersion = "00.00";
+    # Ignore bootloader asserts
+    boot.isContainer = true;
+    # Manual builds will differ since new options are added. This is okay.
+    documentation.nixos.enable = false;
+  };
+  compareEvals = a: b: a.config.system.build.toplevel == b.config.system.build.toplevel;
+  evalConfig = cfg: (import (pkgs.path + "/nixos")) { configuration = { imports = [ cfg baseCfg ]; }; };
+  evalModule = module: evalConfig { imports = [ module ]; };
+  virginEval = evalConfig {};
+  modules = [
+    ../../modules
+  ];
+in
+map (modulePath:
+  let
+    moduleEval = evalConfig modulePath;
+    toplevel = moduleEval.config.system.build.toplevel;
+    vToplevel = virginEval.config.system.build.toplevel;
+  in
+  if !(compareEvals moduleEval virginEval)
+  then
+    builtins.throw ''
+      Module '${toString modulePath}' is not a no-op.
+             ${toString modulePath} != virginEval
+             ${toplevel} != ${vToplevel}
+    ''
+    toplevel
+  else toplevel
+) modules


### PR DESCRIPTION
Enabling the steamos config with enabling steam is the best semantics we have around wanting to use the steamos config... and conversely, not using steam and using the steamos semantics would be *weird* and I think it's fair for it to be opt-in.

The `./support/nix-tests/check-no-ops.nix` script can be used to check that eval of the module is a no-op.

A check has been added for that purpose.

* * *

Example check failing:

 - https://github.com/Jovian-Experiments/Jovian-NixOS/actions/runs/11431517094/job/31800606530?pr=430

(Against this PR, with the modules/steamos no-op commit reverted)

Same check now working:

 - https://github.com/Jovian-Experiments/Jovian-NixOS/actions/runs/11431541868/job/31800668433?pr=430