### PR TITLE
jovian-hardware-survey: Galileo is a thing; RA4 now tested

### DIFF
--- a/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
+++ b/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
@@ -207,7 +207,14 @@ module ReportData
   end
 
   def processor_information()
-    dmi_info["Processor"]["data"]
+    dmi_info["Processor"]["data"].tap do
+      # Convert flags into a Hash, for converting into a JSON Object.
+      _1["Flags"] = _1["Flags"].split("\n").map do |line|
+        data = line.match(%r{^([^\s]+)\s+\((.*)\)$})
+        [data[1], data[2]]
+      end
+        .to_h
+    end
   end
 
   def memory_information()

--- a/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
+++ b/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
@@ -214,6 +214,8 @@ module ReportData
         [data[1], data[2]]
       end
         .to_h
+      # Convert characteristics into an array
+      _1["Characteristics"] = _1["Characteristics"].split("\n")
     end
   end
 

--- a/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
+++ b/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
@@ -345,6 +345,8 @@ module ReportData
     ram_chip_size = memory_information["Devices"][0]["Size"].split(/\s+/, 2)[0].to_i
 
     [
+      "Product Name:         #{system_information["Product Name"]}",
+      "System Family:        #{system_information["Family"]}",
       "Serial:               #{system_information["Serial Number"]}",
       "Manufacturing year:   #{manufacturing_information["Year"]}",
       "Manufacturing week:   #{manufacturing_information["Week"]}",

--- a/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
+++ b/pkgs/jovian-hardware-survey/jovian-hardware-survey.rb
@@ -128,7 +128,10 @@ module ReportData
   end
 
   def is_steam_deck?()
-    system_information["Product Name"] == "Jupiter"
+    [
+      "Jupiter",
+      "Galileo",
+    ].include?(system_information["Product Name"])
   end
 
   FIELDS = [


### PR DESCRIPTION
This change set adds support for Galileo hardware, in addition to fixing support for RA4 hardware.

And on top of that, a bit of data ingestion.

Tested on:


```
 $ sudo /nix/store/ipdh0v4r8vxyaia0zvwkxlgsirhchpwq-jovian-hardware-survey/bin/jovian-hardware-survey --steam-deck-report
Product Name:         Galileo
System Family:        Sephiroth
Serial:               FY1S34300XXX
Manufacturing year:   2023
Manufacturing week:   43
Controller type:      RA4 (0x300)
Controller BL type:   768
Controller HWID:      46
RAM config:           4×4 = 16
RAM Part Number:      MT62F1G64D4AH-023 WT
RAM Manufacturer:     Micron

 $ sudo /nix/store/ipdh0v4r8vxyaia0zvwkxlgsirhchpwq-jovian-hardware-survey/bin/jovian-hardware-survey --steam-deck-report
Product Name:         Jupiter
System Family:        Aerith
Serial:               FWAA15200XXX
Manufacturing year:   2021
Manufacturing week:   52
Controller type:      D21 (0x100)
Controller BL type:   256
Controller HWID:      27
RAM config:           4×4 = 16
RAM Part Number:      MT62F1G32D4DR-031 WT
RAM Manufacturer:     Micron


```

In addition to `--raw` on

```
...
  "system_information": {
    "Manufacturer": "GPD",
    "Product Name": "G1617-01",
    "Version": "Default string",
    "Serial Number": "Default string",
    "Family": "Default string"
  },
...
```