### PR TITLE
Fix dynamic backlight on Steam Deck

### DIFF
--- a/modules/devices/steamdeck/default.nix
+++ b/modules/devices/steamdeck/default.nix
@@ -23,6 +23,7 @@ in
     ./perf-control.nix
     ./sdgyrodsu.nix
     ./sound.nix
+    ./workarounds.nix
   ];
 
   options = {

--- a/modules/devices/steamdeck/workarounds.nix
+++ b/modules/devices/steamdeck/workarounds.nix
@@ -1,0 +1,48 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+
+  cfg = config.jovian.devices.steamdeck;
+in
+{
+  options = {
+    jovian.devices.steamdeck = {
+      enableDeviceDataWorkarounds = mkOption {
+        type = types.bool;
+        default = cfg.enable;
+        defaultText = lib.literalExpression "config.jovian.devices.steamdeck.enable";
+        description = ''
+          Whether to add some workarounds for (Steam Deck) device-specific data.
+        '';
+        # Don't expose to users.
+        internal = true;
+        readOnly = true;
+      };
+    };
+  };
+  config = mkIf (cfg.enableDeviceDataWorkarounds) (mkMerge [
+    {
+      systemd.services."jovian-dmidecode-workaround" = {
+        enable = true;
+        unitConfig.ConditionPathIsDirectory = "/run";
+        before = [ "multi-user.target" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+        };
+        script = ''
+          #!${pkgs.runtimeShell}
+          mkdir -p /run/jovian
+          ${pkgs.dmidecode}/bin/dmidecode -t 11 > /run/jovian/dmidecode-11.txt
+        '';
+      };
+    }
+  ]);
+}

--- a/pkgs/jovian-stubs/sudo
+++ b/pkgs/jovian-stubs/sudo
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
->&2 echo "[JOVIAN] $0: stub called with: $*"
+>&2 printf "[JOVIAN] %s: stub called with: %s\n" "${0##*/}" "$(printf "%q " "$@")"
 
 declare -a final
 
@@ -15,4 +15,8 @@ for value in "$@"; do
     fi
 done
 
-exec "${final[@]}"
+set "${final[@]}"
+
+>&2 printf "[JOVIAN] %s: parsed command: %s\n" "${0##*/}" "$(printf "%q " "$@")"
+
+exec "$@"

--- a/pkgs/jovian-stubs/sudo
+++ b/pkgs/jovian-stubs/sudo
@@ -19,4 +19,15 @@ set "${final[@]}"
 
 >&2 printf "[JOVIAN] %s: parsed command: %s\n" "${0##*/}" "$(printf "%q " "$@")"
 
+case "$*" in
+    # citation:
+    #   - https://github.com/Jovian-Experiments/jupiter-hw-support/blob/86b3de5b64a549b47577472f77f710212857451c/usr/bin/steamos-polkit-helpers/jupiter-get-als-gain#L22C1-L22C16
+    # but we're instead hitting the polkit-helper-less fallback (WARNING: using plain als gain get)
+    "dmidecode -t 11")
+        >&2 printf "[JOVIAN] %s: dmidecode command hijacked with saved data\n" "${0##*/}"
+        cat /run/jovian/dmidecode-11.txt
+        exit 0
+        ;;
+esac
+
 exec "$@"


### PR DESCRIPTION
Fixes #271.

* * *

I have verified that with this change, the backlight changes by itself when *Adaptive Brightness* is enabled. May require photons.

The output of the following command is helpful to check.

```
~ $ grep -i '\bALS: ' ~/.local/share/Steam/logs/* 
...
/Users/samuel/.local/share/Steam/logs/systemmanager.txt:[2024-10-28 23:48:14] [display] ALS: 1, brightness: 1, color management: 1, color temp: 1
```

If `ALS` is `0`, then *something* failed and it's not actually enabled in the end within Steam.

* * *

Quick note about the future.

This is going away. When? Whenever `steamos-manager`.

Proof? none... but there are strong signals:

 - https://github.com/Jovian-Experiments/steamos-manager/blob/579e024fa2f61af8ed16f993afe2f433d0abb655/src/manager/root.rs#L119-L134

Though it's incorrect/incomplete at the moment (no way to get the second sensor's data... and it'd be nice not to rely on the polkit helpers...)