### PR TITLE
jovian-stubs: Use proper quoting for jovian log spew

### DIFF
--- a/pkgs/jovian-stubs/dmidecode
+++ b/pkgs/jovian-stubs/dmidecode
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
->&2 echo "[JOVIAN] $0: stub called with: $*"
+>&2 printf "[JOVIAN] %s: stub called with: %s\n" "${0##*/}" "$(printf "%q " "$@")"
 
 if [ "$*" == "-t 11" ]; then
-    >&2 echo "[JOVIAN] $0: replying with cached data"
+    >&2 echo "[JOVIAN] ${0##*/}: replying with cached data"
     cat /run/jovian/dmidecode-11.txt
     exit 0
 fi
 
->&2 echo "[JOVIAN] $0: don't know how to handle $*"
+>&2 printf "[JOVIAN] %s: don't know how to handle: %s\n" "${0##*/}" "$(printf "%q " "$@")"
 exit 1

--- a/pkgs/jovian-stubs/sudo
+++ b/pkgs/jovian-stubs/sudo
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
->&2 echo "[JOVIAN] $0: stub called with: $*"
+>&2 printf "[JOVIAN] %s: stub called with: %s\n" "${0##*/}" "$(printf "%q " "$@")"
 
 declare -a final
 
@@ -14,5 +14,7 @@ for value in "$@"; do
         final+=("$value")
     fi
 done
+
+>&2 printf "[JOVIAN] %s: parsed command: %s\n" "${0##*/}" "$(printf "%q " "${final[@]}")"
 
 exec "${final[@]}"


### PR DESCRIPTION
Also make the output a bit more readable by keeping the basename of the called stub.

* * *

Fished back up from #433, with added `dmidecode` stub support.