### PR TITLE
modules/steamos: Also enable bluetooth

### DIFF
--- a/modules/steamos/bluetooth.nix
+++ b/modules/steamos/bluetooth.nix
@@ -2,6 +2,7 @@
 
 let
   inherit (lib)
+    mkDefault
     mkIf
     mkOption
     types
@@ -23,6 +24,7 @@ in
   };
 
   config = mkIf (cfg.enableBluetoothConfig) {
+    hardware.bluetooth.enable = mkDefault true;
     # See: https://github.com/Jovian-Experiments/PKGBUILDs-mirror/tree/jupiter-main/bluez
     hardware.bluetooth.settings = {
       General = {


### PR DESCRIPTION
Closes #269

* * *

Checked (disabling first my personal config's usage of bluetooth) with:

```
nix-repl> :p options.hardware.bluetooth.enable.definitionsWithLocations
[
  {
    file = ".../jovian-nixos/modules/steamos/bluetooth.nix";
    value = true;
  }
]
```