### PR TITLE
Add support for Steam IM input methods

### DIFF
--- a/modules/steam/default.nix
+++ b/modules/steam/default.nix
@@ -11,6 +11,7 @@ in
     ./steam.nix
     ./autostart.nix
     ./environment.nix
+    ./inputmethod.nix
   ];
   options = {
     jovian = {

--- a/modules/steam/inputmethod.nix
+++ b/modules/steam/inputmethod.nix
@@ -1,0 +1,60 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkOption
+    types
+    elem
+    mkIf
+    optionals
+    ;
+
+  cfg = config.jovian.steam.inputMethod;
+in
+{
+  options = {
+    jovian = {
+      steam = {
+        inputMethod = {
+          enable = mkOption {
+            type = types.bool;
+            default = false;
+            description = ''
+              Whether to enable the Steam IM support.
+
+              Enable this if you want to enable Steam IM support.
+              This will also set system wide input method to `ibus`.
+            '';
+          };
+          methods = mkOption {
+            type = types.listOf types.str;
+            default = [ ];
+            example = [ "pinyin" "japanese" "korean" ];
+            description = ''
+              List of input methods to enable.
+
+              This option is only used when `enable` is set to `true`.
+            '';
+          };
+        };
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.systemPackages = with pkgs; [
+      steam-im-modules
+    ];
+
+    i18n.inputMethod = {
+      enable = true;
+      type = "ibus";
+      ibus = {
+        engines = with pkgs.ibus-engines;
+          optionals (elem "pinyin" cfg.methods) [ pinyin ]
+          ++ optionals (elem "japanese" cfg.methods) [ anthy ]
+          ++ optionals (elem "korean" cfg.methods) [ hangul ];
+      };
+    };
+  };
+}

--- a/overlay.nix
+++ b/overlay.nix
@@ -83,6 +83,7 @@ rec {
   steam = final.callPackage ./pkgs/steam-jupiter/fhsenv.nix {
     steam = prev.steam;
   };
+  steam-im-modules = final.callPackage ./pkgs/steam-im-modules { };
 
   sdgyrodsu = final.callPackage ./pkgs/sdgyrodsu { };
 

--- a/pkgs/steam-im-modules/default.nix
+++ b/pkgs/steam-im-modules/default.nix
@@ -1,0 +1,41 @@
+{ stdenv
+, fetchFromGitHub
+, extra-cmake-modules
+, libsForQt5
+, gtk3
+, gtk4
+, lib
+}:
+stdenv.mkDerivation {
+  pname = "steam-im-modules";
+  version = "jupiter-20240131";
+
+  src = fetchFromGitHub {
+    owner = "valve-project";
+    repo = "steam-qt-keyboard-plugin";
+    rev = "eab7d4c13bbe1372b7b28731b8209c12037e91af";
+    sha256 = "L9rKEUxDT0fYrvnPIMJS5/wSq1W2KowreaxeXmcCq60=";
+  };
+
+  nativeBuildInputs = [
+    extra-cmake-modules
+    libsForQt5.wrapQtAppsHook
+  ];
+
+  dontWrapQtApps = true;
+
+  buildInputs = [
+    libsForQt5.qtbase
+    gtk3
+    gtk4
+  ];
+
+  cmakeBuildType = "RelWithDebInfo";
+
+  meta = with lib; {
+    description = "Steam Qt Keyboard Plug-in";
+    homepage = "https://github.com/valve-project/steam-qt-keyboard-plugin";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}


### PR DESCRIPTION
Closes #364 
Add support for Chinese Pinyin, Japanese, Korean input methods.

As for Traditional Chinese input methods, `ibus-engines.table-chinese` in `nixpkgs` not working properly, so not adding support for it in this PR (SteamOS is using patched/updated version of it)