### PR TITLE
gamescope: Add Steam Big picture overlay synthesis patch

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -23,7 +23,7 @@ rec {
 
   gamescope = import ./pkgs/gamescope {
     gamescope' = prev.gamescope;
-    inherit (final) fetchFromGitHub;
+    inherit (final) fetchFromGitHub fetchpatch;
   };
   gamescope-wsi = gamescope.override {
     enableExecutable = false;

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -1,9 +1,11 @@
 { gamescope'
+, fetchpatch
 , fetchFromGitHub
 }:
 
 # NOTE: vendoring gamescope for the time being since we want to match the
 #       version shipped by the vendor, ensuring feature level is equivalent.
+#       We're also patching-in features.
 
 gamescope'.overrideAttrs(old: rec {
   version = "3.15.14";
@@ -15,4 +17,14 @@ gamescope'.overrideAttrs(old: rec {
     fetchSubmodules = true;
     hash = "sha256-LVwwkISokjSXEYd/SFRtCDDY6P2sr6pQp8Xb8BsrXAw=";
   };
+
+  patches = old.patches ++ [
+    # wlserver: Sythesize QAM combo on F22
+    # wlserver: Steam Overlay shortcut synthesis on F21
+    # wlserver: Synthesize sythetic steam overlay on keyboard input
+    (fetchpatch {
+      url = "https://github.com/ValveSoftware/gamescope/compare/35cb4fbb2399df205b772295451b875f784ec8d0...2335543009f123d16a141502aa1fe899b38c319f.patch";
+      hash = "sha256-UT5KrnoQ+45AYh73Og1pxVlMRHaJvBULnQhJl8h+SW0=";
+    })
+  ];
 })


### PR DESCRIPTION
This patch set aims to make the Steam Overlay (“Steam Menu”) and the QAM
(“Quick Access Menu”) through additional bindings.

The bindings are the following:

 - F21 → Steam Overlay
 - F22 → QAM

The bindings were chosen so it would be unlikely to clash with any
keyboard input.

The bindings are expected to be used through external configuration,
changing a user-selected input into F21 or F22 to bring those menus.

For example, using udev and hwdb to remap a keyboard key.

Additionally, an in-gamescope method to bring-up the Steam Overlay was
added. This is needed since adding a system-wide remap for the keyboard
is undesirable, when this is a workaround for the lack of a feature
within Steam.