### PR TITLE
modules/hardware: add paddles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 result
 result-*
 .direnv/

--- a/modules/devices/default.nix
+++ b/modules/devices/default.nix
@@ -1,5 +1,6 @@
 {
   imports = [
+    ./legiongo
     ./steamdeck
   ];
 }

--- a/modules/devices/legiongo/default.nix
+++ b/modules/devices/legiongo/default.nix
@@ -30,6 +30,7 @@ in
   config = mkIf cfg.enable {
     jovian.hardware.has = {
       amd.gpu = true;
+      nonNativePaddles = true;
     };
   };
 }

--- a/modules/devices/legiongo/default.nix
+++ b/modules/devices/legiongo/default.nix
@@ -1,0 +1,35 @@
+# Legion Go-specific configurations
+#
+# jovian.devices.legiongo
+
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkOption
+    types
+  ;
+  cfg = config.jovian.devices.legiongo;
+in
+{
+  imports = [
+  ];
+
+  options = {
+    jovian.devices.legiongo = {
+      enable = mkOption {
+        type = types.bool;
+        default = false;
+        description = ''
+          Whether to enable Legion Go-specific configurations.
+        '';
+      };
+    };
+  };
+  config = mkIf cfg.enable {
+    jovian.hardware.has = {
+      amd.gpu = true;
+    };
+  };
+}

--- a/modules/hardware/paddles.nix
+++ b/modules/hardware/paddles.nix
@@ -1,0 +1,29 @@
+{ config, lib, pkgs, ... }:
+
+let
+  inherit (lib)
+    mkIf
+    mkMerge
+    mkOption
+    types
+  ;
+  hardware = config.jovian.hardware;
+  steam = config.jovian.steam;
+in
+{
+  options = {
+    jovian.hardware.has.nonNativePaddles = mkOption {
+    default = false;
+    type = types.bool;
+    description = ''
+      Whether the device has extra buttons like rear paddles that aren't
+      natively supported by the Linux kernel.
+    '';
+  };
+  config = mkIf hardware.has.nonNativePaddles {
+    services.handheld-daemon = {
+      enable = steam.enable;
+      user = steam.user;
+    };
+  };
+}


### PR DESCRIPTION
Here's a draft at adding support for Steam Deck-style controllers that don't have kernel support (like the Steam Deck does).  It just enables `handheld-daemon`, but it's nice to get it automatically for devices that need it (like the Legion Go).

I'll rebase it on #450 when that merges.

I don't know your code style - when to use lowercase vs caps, and if small modules should be in loose files like `paddles.nix`, or in folders `paddles/default.nix`.  Let me know if I need to make any changes there, or anywhere else.