### PR TITLE
Clarify jovian.steam.user description

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -27,7 +27,7 @@ in
         user = mkOption {
           type = types.str;
           description = ''
-            The user to run Steam with.
+            The local system user that Steam will be launched as.
           '';
         };
 


### PR DESCRIPTION
I troubleshooted for days trying to solve why my steam deck wasn't booting into anything. Turns out I had used my steam username instead of my system user. Nobody could tell what was wrong because only I knew that the name I put was the wrong one.

So, I changed `The user to run Steam with.` to `The local system user that Steam will be launched as.`

It doesn't need to be this specific description that I put, we would just want it to be a little more clear.