### PR TITLE
Drop options and packages from "top-level" of the docs (+ fixes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Pointers to helpful pages
 
  - The [Getting Started](docs/getting-started.md) page may be your first stop.
  - The [Configuration](docs/configuration.md) page guides you into configuring your system.
- - The [Options](docs/options.md) is good to know all that you can do.
 
 <div class="for-github -unneeded">
 <hr />

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,10 +1,10 @@
 FAQ
 ===
 
-> **Jovian**
+> **Jovian**  
 > “Relating to [...] Jupiter or the class of [...] which Jupiter belongs.”
 
-> What's Jupiter?
+### What's Jupiter?
 
 [There's a disambiguation page that won't help you](https://en.wikipedia.org/wiki/Jupiter_(disambiguation)).
 It's not known *exactly* what it's the codename for.
@@ -12,9 +12,7 @@ It is either the codename for the Steam Deck, or the codename for the new Steam 
 Things get awfully murky with *Neptune* also being a thing, and it's unclear from the outside what it is.
 To the best of our knowledge, Jupiter is the OS.
 
-* * *
-
-> What channels are supported?
+### What channels are supported?
 
 Truthfully, no channel is *supported*, but the older the stable release was cut, the more likely the additions from Jovian NixOS won't work as expected.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,10 +1,7 @@
 Configuration
 =============
 
-All available module options along with their descriptions can be found under `modules`.
-The options are also listed on the [options page in the documentation](https://jovian-experiments.github.io/Jovian-NixOS/options.html).
-
-### Using the Steam Deck UI
+## Using the Steam Deck UI
 
 To use the Steam Deck UI, set `jovian.steam.enable = true;` in your configuration.
 
@@ -13,7 +10,7 @@ This will only enable the Steam Deck UI tooling.
 
 The Steam Deck UI can be used in different manners.
 
-#### Autostart
+### Autostart
 
 (*This is the preferred way to use the Steam Deck interface*)
 
@@ -28,14 +25,14 @@ If you want the *Switch to Desktop* menu option to switch to another session, yo
 Configure it with the name of the X11 or Wayland session of your choosing.
 The session name semantics are the same as for the `services.displayManager.defaultSession` NixOS option.
 
-#### As a user session
+### As a user session
 
 Select the *Gaming Mode* sesssion in your Display Manager, or run `start-gamescope-session` in a VT.
 
 The *Switch to Desktop* option will not work as intended, instead it will close Steam.
 
 
-#### As a *nested* window
+### As a *nested* window
 
 Run `gamescope-session` within an existing desktop session.
 
@@ -44,3 +41,12 @@ This will run [gamescope](https://github.com/ValveSoftware/gamescope) in nested 
 Usage as a *nested* window is less tested, and may have other undesirable idiosyncrasies.
 
 The *Switch to Desktop* option will not work as intended, instead it will close Steam.
+
+
+## Going further
+
+This is a NixOS system, you can do much more.
+[All the usual NixOS options are available](https://search.nixos.org/options?channel=unstable).
+
+In addition to that, all the Jovian NixOS options, including internal implementation details,
+are listed on the [options page in the documentation](https://jovian-experiments.github.io/Jovian-NixOS/options.html).

--- a/docs/devices/valve-steam-deck/index.md
+++ b/docs/devices/valve-steam-deck/index.md
@@ -28,4 +28,4 @@ Connect to the dock via USB-C and run `jupiter-dock-updater` to update.
 Helpful Tips
 ------------
 
-To enter the boot menu, power off the Steam Deck then hold down `Volume-` and tap the `Power` button.
+To enter the boot menu, power off the Steam Deck then hold down `Volume Down` and tap the `Power` button.

--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -4,3 +4,4 @@ In-Depth
 Learn more about:
 
  - [Using Decky Loader](in-depth/decky-loader.md)
+ - [All the options](options.md)

--- a/docs/in-depth.md
+++ b/docs/in-depth.md
@@ -5,3 +5,4 @@ Learn more about:
 
  - [Using Decky Loader](in-depth/decky-loader.md)
  - [All the options](options.md)
+ - [All the packages](packages.md)

--- a/docs/options.md
+++ b/docs/options.md
@@ -2,9 +2,15 @@
 
 Jovian-NixOS adds a set of extra options that can be used in your NixOS configurations under the `jovian` prefix.
 
+Most of these options are implementation details, and likely are not needed to be changed.
+
+See the [Getting Started](docs/getting-started.md) page and the [Configuration](docs/configuration.md) page for the options that matter.
+
+* * *
+
 <div class="for-github -unneeded">
 
 > [!NOTE]  
-> The options listing is available on the website.
+> [The options listing is available on the website.](https://jovian-experiments.github.io/Jovian-NixOS/options.html)
 
 </div>

--- a/docs/packages.md
+++ b/docs/packages.md
@@ -1,10 +1,16 @@
 # Packages
 
-Jovian-NixOS adds a set of extra packages that can be used in your NixOS configurations.
+Jovian-NixOS provides an overlay with a set of extra packages.
+
+Most of these packages are used implicitly from the Jovian NixOS configuration, and are an implementation detail.
+
+See the [Getting Started](docs/getting-started.md) page and the [Configuration](docs/configuration.md) page for the options that will end-up using or enabling them.
+
+* * *
 
 <div class="for-github -unneeded">
 
 > [!NOTE]  
-> The options listing is available on the website only.
+> [The packages listing is available on the website only.](https://jovian-experiments.github.io/Jovian-NixOS/packages.html)
 
 </div>

--- a/support/docs/default.nix
+++ b/support/docs/default.nix
@@ -87,10 +87,10 @@ let
       # https://pagefind.app/docs/hosting/#hosting-on-github-pages
       pagefind \
         --verbose \
-        --bundle-dir !pagefind \
+        --output-subdir !pagefind \
         --root-selector 'body > main' \
         --keep-index-url \
-        --source .
+        --site .
 
       for p in "''${OPT_OUT[@]}"; do
         mv -v $p.xxx $p.html

--- a/support/docs/styles/common/layout.less
+++ b/support/docs/styles/common/layout.less
@@ -117,6 +117,11 @@ code, pre {
   border-radius: 0.5*@gutter;
   line-height: @line-height - (0.2); // border should not make line bigger
 }
+a > code {
+	background: unset;
+	border: unset;
+	padding: unset;
+}
 
 // Some page generators use that DOM layout.
 pre code {

--- a/support/docs/template/main.erb
+++ b/support/docs/template/main.erb
@@ -28,7 +28,6 @@
     #["FAQ", "FAQ"],
     ["getting-started", "Getting Started"],
     ["in-depth", "In Depth"],
-    ["packages", "Packages"],
     ["contributing", "Contributing"],
     # NOTE: keep last
     ["search", "Search"],

--- a/support/docs/template/main.erb
+++ b/support/docs/template/main.erb
@@ -25,8 +25,8 @@
         <ul>
 <%
   [
-    #["FAQ", "FAQ"],
     ["getting-started", "Getting Started"],
+    ["FAQ", "FAQ"],
     ["in-depth", "In Depth"],
     ["contributing", "Contributing"],
     # NOTE: keep last

--- a/support/docs/template/main.erb
+++ b/support/docs/template/main.erb
@@ -28,7 +28,6 @@
     #["FAQ", "FAQ"],
     ["getting-started", "Getting Started"],
     ["in-depth", "In Depth"],
-    ["options", "Options"],
     ["packages", "Packages"],
     ["contributing", "Contributing"],
     # NOTE: keep last


### PR DESCRIPTION
The options, as noted in the matrix room, are full of implementation details and internals.

Instead, we should prefer describing in topically-relevant pages how to use the options that matter for end-users.

Ideally, we'd have `options.level.type = types.enum [ "primary" "secondary" "internal" ];` or something like that, so we could hide the internal options (just like is possible right now already), and de-prioritize the internals in the options listing.


* * *

### What was done

```
 $ nix-build -A documentation && (cd result; nix-shell -p ruby --run 'ruby -run -e httpd')
```

Then looked around [http://localhost:8080/](http://localhost:8080/) to see if anything was off.