### PR TITLE
linux-jovian: 6.8.12-valve7 -> 6.8.12-valve11 + suspend fix

### DIFF
--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -4,8 +4,8 @@ let
   inherit (lib) versions;
 
   kernelVersion = "6.8.12";
-  vendorVersion = "valve7";
-  hash = "sha256-B0x40FuHeoE+9YBe3N3o2Hzz54hreCa6gQ0HFl7FzPU=";
+  vendorVersion = "valve11-jovian1";
+  hash = "sha256-MBp504pWVynZUS3I3tnL8kfkrkH1+KXgWjBcru1y/7E=";
 in
 buildLinux (args // rec {
   version = "${kernelVersion}-${vendorVersion}";


### PR DESCRIPTION
Revert the wake on BT commits as those seem to break resume on LCD Decks.