### PR TITLE
steamos-automount: support all of the filesystems

### DIFF
--- a/pkgs/jupiter-hw-support/automount-support-extra-filesystems.patch
+++ b/pkgs/jupiter-hw-support/automount-support-extra-filesystems.patch
@@ -1,0 +1,38 @@
+diff --git a/usr/lib/hwsupport/holo-automount.sh b/usr/lib/hwsupport/holo-automount.sh
+index 386f4d8..21932c0 100755
+--- a/usr/lib/hwsupport/holo-automount.sh
++++ b/usr/lib/hwsupport/holo-automount.sh
+@@ -67,16 +67,28 @@ do_mount()
+     #fi
+ 
+     # We need symlinks for Steam for now, so only automount ext4 as that'll Steam will format right now
+-    if [[ ${ID_FS_TYPE} != "ext4" ]]; then
+-        echo "Error mounting ${DEVICE}: wrong fstype: ${ID_FS_TYPE} - ${dev_json}"
+-        exit 2
+-    fi
+ 
+     # Try to repair the filesystem if it's known to have errors.
+     # ret=0 means no errors, 1 means that errors were corrected.
+     # In all other cases we try to mount the fs read-only and report an error.
+     ret=0
+-    fsck.ext4 -y "${DEVICE}" || ret=$?
++    case "${ID_FS_TYPE}" in
++      # null: unformatted partition
++      # ntfs: filename incompatibilities with proton
++      # exfat, udf, vfat: no symlink support
++      "null" | "ntfs" | "exfat" | "udf" | "vfat")
++        echo "Error mounting ${DEVICE}: wrong fstype: ${ID_FS_TYPE} - ${dev_json}"
++        exit ${MOUNT_ERROR}
++        ;;
++
++      # these actually have fsck implementations we can use
++      "ext4")
++        fsck.ext4 -y "${DEVICE}" || ret=$?
++        ;;
++      "f2fs")
++        fsck.f2fs -y "${DEVICE}" || ret=$?
++        ;;
++    esac
+     if (( ret != 0 && ret != 1 )); then
+         send_steam_url "system/devicemountresult" "${DEVBASE}/${FSCK_ERROR}"
+         echo "Error running fsck on ${DEVICE} (status = $ret)"

--- a/pkgs/jupiter-hw-support/default.nix
+++ b/pkgs/jupiter-hw-support/default.nix
@@ -6,6 +6,7 @@
 , coreutils
 , e2fsprogs
 , exfatprogs
+, f2fs-tools
 , f3
 , findutils
 , gawk
@@ -28,6 +29,7 @@ let
       coreutils
       e2fsprogs
       exfatprogs
+      f2fs-tools
       f3
       findutils
       gawk
@@ -44,6 +46,7 @@ let
     execer = [
       "cannot:${e2fsprogs}/bin/fsck.ext4"
       "cannot:${e2fsprogs}/bin/mkfs.ext4"
+      "cannot:${f2fs-tools}/bin/fsck.f2fs"
       "cannot:${procps}/bin/pgrep"
       "cannot:${systemd}/bin/systemctl"
       "cannot:${systemd}/bin/udevadm"

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -27,6 +27,7 @@ stdenv.mkDerivation rec {
     # Minor fixes against silly environments
     ./0001-steamos-automount-Harden-against-missing-run-media.patch
     ./0001-format-device-Harden-against-mountpoint-being-listed.patch
+    ./automount-support-extra-filesystems.patch
   ];
 
   # broken symlinks will be filled in later


### PR DESCRIPTION
Alternate solution to #414.
This will automount any filesystem that is not in the list of known bad filesystems.