### PR TITLE
overlay: Guard against repeat overlaying

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -15,6 +15,31 @@ let
     linuxPackagesFor
   ;
 in
+
+if prev ? linux_jovian then builtins.throw ''
+  ${""  }The Jovian NixOS overlay was already previously imported in this
+         NixOS configuration. This is unsupported, and may cause build failures.
+
+         Please make sure that you are not adding the Jovian NixOS overlay
+         to `nixpkgs.overlays` in your NixOS configuration.
+
+         Adding the overlay is not needed when importing the Jovian NixOS
+         module in your configuration.
+
+         If you are not using the Jovian NixOS modules, make sure the
+         overlay is not being imported twice.
+
+         The overlay is not part of the public interface, and care should
+         be taken when using it directly.
+
+         * * *
+         Technical detail:
+         This is checking for `linux_jovian` being already set. If another
+         module or overlay is adding `linux_jovian` to the package set, it
+         may also trigger this error.
+         * * *
+'' else
+
 rec {
   linux-firmware-jupiter = final.callPackage ./pkgs/linux-firmware {
     linux-firmware = prev.linux-firmware;

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,3 +1,12 @@
+#
+# █▀▀▀▀▀▀▀▀▀▀▀█▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀█
+# █  WARNING  █  This overlay.nix file is not a public interface.  █
+# █▄▄▄▄▄▄▄▄▄▄▄█▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄█
+#
+# Importing this overlay in your NixOS configuration may cause unexpected
+# errors. Import the Jovian NixOS modules in your NixOS configuration,
+# which will import this overlay correctly.
+# 
 final: prev:
 
 let

--- a/overlay.nix
+++ b/overlay.nix
@@ -102,7 +102,7 @@ rec {
   jovian-steam-protocol-handler = final.callPackage ./pkgs/jovian-steam-protocol-handler { };
   jovian-updater-logo-helper = final.callPackage ./pkgs/jovian-updater-logo-helper { };
 
-  jovian-documentation = final.callPackage ./support/docs {
+  jovian-documentation = pkgs'WithoutGuardClause.callPackage ./support/docs {
     documentationPath = final.callPackage (
       { runCommand
       }:

--- a/overlay.nix
+++ b/overlay.nix
@@ -40,6 +40,15 @@ if prev ? linux_jovian && !( prev.__jovian_ignore_guard or false ) then builtins
          * * *
 '' else
 
+let
+  # The different parts of this tooling need to "peek" into the overlay.
+  # (Mainly to read the overlaid package metadata.)
+  pkgs'WithoutGuardClause =
+    final.appendOverlays [(_: _: {
+      __jovian_ignore_guard = true;
+    })]
+  ;
+in
 rec {
   linux-firmware-jupiter = final.callPackage ./pkgs/linux-firmware {
     linux-firmware = prev.linux-firmware;

--- a/overlay.nix
+++ b/overlay.nix
@@ -16,7 +16,7 @@ let
   ;
 in
 
-if prev ? linux_jovian then builtins.throw ''
+if prev ? linux_jovian && !( prev.__jovian_ignore_guard or false ) then builtins.throw ''
   ${""  }The Jovian NixOS overlay was already previously imported in this
          NixOS configuration. This is unsupported, and may cause build failures.
 

--- a/support/test-configs/README.md
+++ b/support/test-configs/README.md
@@ -1,0 +1,8 @@
+Test configs
+============
+
+These configurations ***are not necessarily meant to represent correct usage of Jovian NixOS***!!!
+
+They are used to test specific use-cases.
+
+Read them carefully, and if you're not sure what they are doing, please ask.

--- a/support/test-configs/bad-overlaying-twice/configuration.nix
+++ b/support/test-configs/bad-overlaying-twice/configuration.nix
@@ -1,0 +1,13 @@
+{
+  imports = [
+    ../../../modules
+  ];
+
+  # WARNING: Never import the overlay in this way.
+  #          The modules handles importing the overlay already.
+  #          See: https://github.com/Jovian-Experiments/Jovian-NixOS/issues/486
+  nixpkgs.overlays = [
+    # This overlay.nix file is not a public interface.
+    (import ../../../overlay.nix)
+  ];
+}

--- a/support/test-configs/bad-overlaying-twice/default.nix
+++ b/support/test-configs/bad-overlaying-twice/default.nix
@@ -1,0 +1,17 @@
+#
+# This test config can be checked with:
+#
+# ```
+#  $ nix-instantiate ./support/test-configs/bad-overlaying-twice/
+# ```
+#
+# It should error out in a controlled manner.
+#
+{ pkgs ? import ../../../nixpkgs.nix {} }:
+
+let
+  eval = (import (pkgs.path + "/nixos")) {
+    configuration = ./configuration.nix;
+  };
+in
+  eval.pkgs.gamescope


### PR DESCRIPTION
Multiple users have ended-up accidentally doing this, or the equivalent of this in their configuration:

```nix
{
  imports = [ "${jovian}/modules" ];
  nixpkgs.overlays = [ jovian.overlays.default ];
}
```

When the overlay *overrides* an existing package, like for example the `gamescope` package, this package gets the override applied twice.

In turn, if the override *appends* to the package attributes, the appended values will be present twice.

Finally, when patches are attempted to be applied twice, all hell breaks loose.

Fixes #486

cc @mweinelt

* * *

### What was done

 - Ran the `bad-overlaying-twice` test config.
    - Checked that it errored out as expected.
 - Fix the documentation build to not trigger the check :thinking:.
    - It's happening *at the very least* when evaluating the options for the documentation.
    - And also happened when peeking at the overlay attributes.

### What needs to be done

 - Adding to my personal configuration to double-check it's really not accidentally doing something bad. (It shouldn't be,)
 - Ideally someone with a Flake-based NixOS configuration should verify this is fine, too. Though Flakes or no-Flakes shouldn't matter here.