### PR TITLE
gamescope-session, steam-jupiter: allow overriding steamdeck arg

### DIFF
--- a/pkgs/gamescope-session/environment.patch
+++ b/pkgs/gamescope-session/environment.patch
@@ -1,16 +1,29 @@
 diff --git a/gamescope-session b/gamescope-session
-index 7101e70..2ff1bd5 100755
+index 1fea3be..b41e819 100755
 --- a/gamescope-session
 +++ b/gamescope-session
-@@ -243,6 +243,11 @@ else
-        echo >&2 "!! Failed to claim global gamescope stats session"
+@@ -245,6 +245,11 @@ else
+ 	echo >&2 "!! Failed to claim global gamescope stats session"
  fi
-
+ 
 +# Jovian NixOS environment overrides hook
 +if test -e /etc/xdg/gamescope-session/environment; then
 +       . /etc/xdg/gamescope-session/environment;
 +fi
 +
  read_gamescope_env() {
-        if read -r -t 3 response_x_display response_wl_display <> "$socket"; then
-                export DISPLAY="$response_x_display"
+ 	if read -r -t 3 response_x_display response_wl_display <> "$socket"; then
+ 		export DISPLAY="$response_x_display"
+diff --git a/steam-launcher b/steam-launcher
+index d574495..d205026 100644
+--- a/steam-launcher
++++ b/steam-launcher
+@@ -1,6 +1,7 @@
+ #!/bin/bash
+ 
+-steamargs=("-steamos3" "-steampal" "-steamdeck" "-gamepadui")
++# Jovian: remove -steamdeck here so we can set it in the wrapper instead
++steamargs=("-gamepadui")
+ if [[ -x $HOME/devkit-game/devkit-steam ]]; then
+ 	exec "$HOME"/devkit-game/devkit-steam "${steamargs[@]}"
+ else

--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -5,7 +5,12 @@
 , dmidecode
 , jovian-stubs
 , steam
-  # , steamos-polkit-helpers
+
+# We need to add this flag when Steam is started directly (e.g., desktop mode)
+# so we have the correct client version. This is important even for desktop
+# use because only the Steam Deck branch of the client has the new on-screen
+# keyboard that's summoned with STEAM + X.
+, platformArgs ? "-steamos3 -steampal -steamdeck"
 , ...
 } @ args:
 
@@ -16,6 +21,7 @@ let
     "writeShellScriptBin"
     "dmidecode"
     "jovian-stubs"
+    "platformArgs"
     "steam"
     "steamos-polkit-helpers"
   ];
@@ -61,11 +67,7 @@ let
       "--bind /tmp /tmp"
     ];
 
-    # We need to add this flag when Steam is started directly (e.g., desktop mode)
-    # so we have the correct client version. This is important even for desktop
-    # use because only the Steam Deck branch of the client has the new on-screen
-    # keyboard that's summoned with STEAM + X.
-    extraArgs = (args.extraArgs or "") + " -steamdeck";
+    extraArgs = (args.extraArgs or "") + " " + platformArgs;
   });
 in
 wrappedSteam


### PR DESCRIPTION
This allows opting out of Steam Deck client branch, via e.g.

```nix
nixpkgs.overlays = [
  (final: prev: {
    steam = prev.steam.override { platformArgs = ""; } 
  })
];
```