### PR TITLE
treewide: run treefmt on pkgs to align with nix RFC conventions.

### DIFF
--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -1,10 +1,11 @@
-{ lib
-, fetchFromGitHub
-, nodejs
-, pnpm_9
-, python3
-, coreutils
-, psmisc
+{
+  lib,
+  fetchFromGitHub,
+  nodejs,
+  pnpm_9,
+  python3,
+  coreutils,
+  psmisc,
 }:
 python3.pkgs.buildPythonPackage rec {
   pname = "decky-loader";
@@ -39,7 +40,7 @@ python3.pkgs.buildPythonPackage rec {
     cd ../backend
   '';
 
-  build-system = with python3.pkgs; [ 
+  build-system = with python3.pkgs; [
     poetry-core
     poetry-dynamic-versioning
   ];
@@ -56,7 +57,12 @@ python3.pkgs.buildPythonPackage rec {
   ];
 
   makeWrapperArgs = [
-    "--prefix PATH : ${lib.makeBinPath [ coreutils psmisc ]}"
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        coreutils
+        psmisc
+      ]
+    }"
   ];
 
   pythonRelaxDeps = [

--- a/pkgs/decky-loader/prerelease.nix
+++ b/pkgs/decky-loader/prerelease.nix
@@ -1,4 +1,4 @@
-{ 
+{
   decky-loader,
 }:
 decky-loader

--- a/pkgs/galileo-mura/default.nix
+++ b/pkgs/galileo-mura/default.nix
@@ -1,23 +1,27 @@
-{ lib
-, stdenv
-, fetchFromGitHub
-, meson
-, ninja
-, resholve
-, bash
-, writeText
-, coreutils
-, findutils
-, gawk
-, gnugrep
-, gnused
-, gnutar
-, wget
-, xorg
+{
+  lib,
+  stdenv,
+  fetchFromGitHub,
+  meson,
+  ninja,
+  resholve,
+  bash,
+  writeText,
+  coreutils,
+  findutils,
+  gawk,
+  gnugrep,
+  gnused,
+  gnutar,
+  wget,
+  xorg,
 }:
 let
   solution = {
-    scripts = [ "bin/galileo-mura-download" "bin/galileo-mura-setup" ];
+    scripts = [
+      "bin/galileo-mura-download"
+      "bin/galileo-mura-setup"
+    ];
     interpreter = "${bash}/bin/bash";
     inputs = [
       coreutils
@@ -36,7 +40,7 @@ let
       "cannot:${placeholder "out"}/bin/galileo-mura-download"
     ];
 
-    fake.external = ["galileo-mura-extractor"];
+    fake.external = [ "galileo-mura-extractor" ];
 
     prologue = "${writeText "gamescope-session-prologue" ''
       export PATH=/run/wrappers/bin:$PATH
@@ -54,7 +58,7 @@ stdenv.mkDerivation rec {
     hash = "sha256-eM4UHYCgj2vwK8cxh6KKta7gpFjX/7bwS7VJaKsBG7c=";
   };
 
-  patches = [./home.patch];
+  patches = [ ./home.patch ];
 
   nativeBuildInputs = [
     meson

--- a/pkgs/gamescope-session/default.nix
+++ b/pkgs/gamescope-session/default.nix
@@ -63,7 +63,7 @@ let
       # Don't resholve gamescope so we can use the cap_sys_nice wrapper when available
       # mangohud is not picked up by resholve due to loop_background
       export PATH=/run/wrappers/bin:${gamescope}/bin:$PATH
-  
+
       # Make gamescope discover the Steam cursor theme
       export XCURSOR_PATH=${kdePackages.breeze}/share/icons:${steamdeck-hw-theme}/share/icons
 
@@ -111,7 +111,8 @@ let
       gnutar
     ];
   };
-in stdenv.mkDerivation(finalAttrs: {
+in
+stdenv.mkDerivation (finalAttrs: {
   pname = "gamescope-session";
   version = "3.16.15-2";
 
@@ -127,7 +128,10 @@ in stdenv.mkDerivation(finalAttrs: {
     (replaceVars ./portals.patch {
       gamescope-portals = symlinkJoin {
         name = "gamescope-portals";
-        paths = [ xdg-desktop-portal-gamescope xdg-desktop-portal-holo ];
+        paths = [
+          xdg-desktop-portal-gamescope
+          xdg-desktop-portal-holo
+        ];
       };
     })
   ];
@@ -155,7 +159,7 @@ in stdenv.mkDerivation(finalAttrs: {
     substituteInPlace steam-notif-daemon.service --replace-fail /usr/bin ${steam_notif_daemon}/bin
   '';
 
-  nativeBuildInputs = [python3];
+  nativeBuildInputs = [ python3 ];
 
   # Largely copied from upstream
   installPhase = ''
@@ -177,7 +181,7 @@ in stdenv.mkDerivation(finalAttrs: {
     install -D -m 644 gamescope-session.service $out/lib/systemd/user/gamescope-session.service
     install -D -m 644 gamescope-session.target $out/lib/systemd/user/gamescope-session.target
     install -D -m 644 gamescope-mangoapp.service $out/lib/systemd/user/gamescope-mangoapp.service
-    install -D -m 644 ibus-gamescope.service  $out/lib/systemd/user/ibus-gamescope.service 
+    install -D -m 644 ibus-gamescope.service  $out/lib/systemd/user/ibus-gamescope.service
     install -D -m 644 steam-launcher.service $out/lib/systemd/user/steam-launcher.service
     install -D -m 644 steam-notif-daemon.service $out/lib/systemd/user/steam-notif-daemon.service
     # Jovian: don't install this, it's not useful for us
@@ -194,5 +198,5 @@ in stdenv.mkDerivation(finalAttrs: {
     runHook postInstall
   '';
 
-  passthru.providedSessions = ["gamescope-wayland"];
+  passthru.providedSessions = [ "gamescope-wayland" ];
 })

--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -1,4 +1,4 @@
-{ 
+{
   gamescope',
   fetchFromGitHub,
 }:
@@ -6,7 +6,7 @@
 # NOTE: vendoring gamescope for the time being since we want to match the
 #       version shipped by the vendor, ensuring feature level is equivalent.
 
-gamescope'.overrideAttrs(old: rec {
+gamescope'.overrideAttrs (old: rec {
   version = "3.16.15";
 
   src = fetchFromGitHub {

--- a/pkgs/jovian-greeter/default.nix
+++ b/pkgs/jovian-greeter/default.nix
@@ -1,4 +1,12 @@
-{ lib, stdenv, python3, plymouth, shellcheck, nodePackages, rustPlatform }:
+{
+  lib,
+  stdenv,
+  python3,
+  plymouth,
+  shellcheck,
+  nodePackages,
+  rustPlatform,
+}:
 
 stdenv.mkDerivation {
   name = "jovian-greeter";

--- a/pkgs/jovian-hardware-survey/default.nix
+++ b/pkgs/jovian-hardware-survey/default.nix
@@ -1,15 +1,21 @@
-{ lib
-, runCommand
-, ruby
-, steamdeck-firmware
-, dmidecode
+{
+  lib,
+  runCommand,
+  ruby,
+  steamdeck-firmware,
+  dmidecode,
 }:
 
 runCommand "jovian-hardware-survey" { } ''
   mkdir -p $out/bin
   (
   echo "#!${ruby}/bin/ruby"
-  echo 'ENV["PATH"] = "${lib.makeBinPath [ steamdeck-firmware dmidecode ]}:#{ENV["PATH"]}"'
+  echo 'ENV["PATH"] = "${
+    lib.makeBinPath [
+      steamdeck-firmware
+      dmidecode
+    ]
+  }:#{ENV["PATH"]}"'
   echo 'D20BOOTLOADER = "${steamdeck-firmware}/libexec/d20bootloader"'
   cat ${./jovian-hardware-survey.rb}
   ) > $out/bin/jovian-hardware-survey

--- a/pkgs/jovian-updater-logo-helper/default.nix
+++ b/pkgs/jovian-updater-logo-helper/default.nix
@@ -1,7 +1,8 @@
-{ writeShellApplication
-, lib
-, drm_info
-, imagemagick
+{
+  writeShellApplication,
+  lib,
+  drm_info,
+  imagemagick,
 
 }:
 

--- a/pkgs/jupiter-dock-updater-bin/default.nix
+++ b/pkgs/jupiter-dock-updater-bin/default.nix
@@ -1,11 +1,12 @@
-{ stdenv
-, fetchFromGitHub
-, autoPatchelfHook
-, makeWrapper
-, libusb1
+{
+  stdenv,
+  fetchFromGitHub,
+  autoPatchelfHook,
+  makeWrapper,
+  libusb1,
 }:
 
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jupiter-dock-updater-bin";
   version = "20250220.02";
 

--- a/pkgs/jupiter-fan-control/default.nix
+++ b/pkgs/jupiter-fan-control/default.nix
@@ -1,6 +1,11 @@
-{ lib, stdenv, python3, fetchFromGitHub }:
+{
+  lib,
+  stdenv,
+  python3,
+  fetchFromGitHub,
+}:
 
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "jupiter-fan-control";
   version = "20240523.3";
 
@@ -12,9 +17,11 @@ stdenv.mkDerivation(finalAttrs: {
   };
 
   buildInputs = [
-    (python3.withPackages (py: with py; [
-      pyyaml
-    ]))
+    (python3.withPackages (
+      py: with py; [
+        pyyaml
+      ]
+    ))
   ];
 
   dontConfigure = true;

--- a/pkgs/jupiter-hw-support/bios-fwupd.nix
+++ b/pkgs/jupiter-hw-support/bios-fwupd.nix
@@ -5,97 +5,101 @@
 #    (WARNING: This may make your device less secure!)
 # 3. Run `sudo fwupdmgr install /path/to/bios.cab`
 
-{ lib
-, runCommand
-, callPackage
-, jupiter-hw-support
-, gcab
+{
+  lib,
+  runCommand,
+  callPackage,
+  jupiter-hw-support,
+  gcab,
 
-# The following parameters are for your enjoyment of flashing custom/older BIOSes:
+  # The following parameters are for your enjoyment of flashing custom/older BIOSes:
 
-# Board prefixes to build the output for.
-, boards ? [
-  "F7A" # Jupiter
-  "F7G" # Galileo
-]
+  # Board prefixes to build the output for.
+  boards ? [
+    "F7A" # Jupiter
+    "F7G" # Galileo
+  ],
 
-# Directory containing the BIOS files.
-, biosSource ? callPackage ./src.nix { }
+  # Directory containing the BIOS files.
+  biosSource ? callPackage ./src.nix { },
 
-# The release date of the BIOS for the fwupd manifest.
-, releaseDate ? "1970-01-01"
+  # The release date of the BIOS for the fwupd manifest.
+  releaseDate ? "1970-01-01",
 
-# The human-readable version for the package.
-, packageVersion ? jupiter-hw-support.src.version
+  # The human-readable version for the package.
+  packageVersion ? jupiter-hw-support.src.version,
 }:
 
 let
   version = if packageVersion != null then packageVersion else jupiter-hw-support.version;
 
-in runCommand "steamdeck-bios-fwupd-${version}" {
-  inherit boards biosSource releaseDate;
+in
+runCommand "steamdeck-bios-fwupd-${version}"
+  {
+    inherit boards biosSource releaseDate;
 
-  nativeBuildInputs = [ gcab ];
+    nativeBuildInputs = [ gcab ];
 
-  meta = with lib; {
-    description = "Steam Deck BIOS for fwupd";
-    license = licenses.unfreeRedistributableFirmware;
-  };
-} ''
-  for board in $boards; do
-    >&2 echo ":: Building archive for board '$board'"
+    meta = with lib; {
+      description = "Steam Deck BIOS for fwupd";
+      license = licenses.unfreeRedistributableFirmware;
+    };
+  }
+  ''
+    for board in $boards; do
+      >&2 echo ":: Building archive for board '$board'"
 
-    biosFile=$(find "$biosSource" -regextype posix-extended -type f -regex ".*/''${board}[0-9]{4}_sign.fd" | head -1)
+      biosFile=$(find "$biosSource" -regextype posix-extended -type f -regex ".*/''${board}[0-9]{4}_sign.fd" | head -1)
 
-    >&2 echo ":: Found BIOS file '$biosFile'"
+      >&2 echo ":: Found BIOS file '$biosFile'"
 
-    versionPair=$(basename "$biosFile" | sed 's/^.*'"$board"'\([0-9]\{2\}\)\([0-9]\{2\}\).*$/\1 \2/; t; q1')
+      versionPair=$(basename "$biosFile" | sed 's/^.*'"$board"'\([0-9]\{2\}\)\([0-9]\{2\}\).*$/\1 \2/; t; q1')
 
-    get_numeric_ver() { printf "%d" "0x00$100$2"; }
-    export versionNumber=$(get_numeric_ver $versionPair)
+      get_numeric_ver() { printf "%d" "0x00$100$2"; }
+      export versionNumber=$(get_numeric_ver $versionPair)
 
-    >&2 echo ":: Detected numeric BIOS version $versionNumber"
+      >&2 echo ":: Detected numeric BIOS version $versionNumber"
 
-    uefi_guid=bbb1cf06-f7b9-4466-adcc-6b8815bd99e6
+      uefi_guid=bbb1cf06-f7b9-4466-adcc-6b8815bd99e6
 
-    # Run `fwupdtool hwids`
-    # Manufacturer + Family + ProductName
-    case "$board" in
-      F7A)
-        # Manufacturer: Valve
-        # Family: Aerith
-        # ProductName: Jupiter
-        hwid=c92f10e2-b04e-59fd-9a1c-e9f354fe80d0
-        model="LCD [Jupiter]"
-        ;;
-      F7G)
-        # Manufacturer: Valve
-        # Family: Sephiroth
-        # ProductName: Galileo
-        hwid=642e9dd3-94fe-5b66-a403-5e765427de87
-        model="OLED [Galileo]"
-        ;;
-      *)
-        >&2 echo ":: No GUID for board '$board'"
-        exit 1
-        ;;
-    esac
+      # Run `fwupdtool hwids`
+      # Manufacturer + Family + ProductName
+      case "$board" in
+        F7A)
+          # Manufacturer: Valve
+          # Family: Aerith
+          # ProductName: Jupiter
+          hwid=c92f10e2-b04e-59fd-9a1c-e9f354fe80d0
+          model="LCD [Jupiter]"
+          ;;
+        F7G)
+          # Manufacturer: Valve
+          # Family: Sephiroth
+          # ProductName: Galileo
+          hwid=642e9dd3-94fe-5b66-a403-5e765427de87
+          model="OLED [Galileo]"
+          ;;
+        *)
+          >&2 echo ":: No GUID for board '$board'"
+          exit 1
+          ;;
+      esac
 
-    export model
-    export board
-    export hwid
-    export uefi_guid
-    export filename=$(basename "$biosFile")
-    export sha1=$(sha1sum "$biosFile" | awk '{ print $1 }')
-    export sha256=$(sha1sum "$biosFile" | awk '{ print $1 }')
-    substituteAll ${./SteamDeckBIOS.metainfo.xml} SteamDeckBIOS.metainfo.xml
+      export model
+      export board
+      export hwid
+      export uefi_guid
+      export filename=$(basename "$biosFile")
+      export sha1=$(sha1sum "$biosFile" | awk '{ print $1 }')
+      export sha256=$(sha1sum "$biosFile" | awk '{ print $1 }')
+      substituteAll ${./SteamDeckBIOS.metainfo.xml} SteamDeckBIOS.metainfo.xml
 
-    >&2 echo ":: Generated metainfo file"
+      >&2 echo ":: Generated metainfo file"
 
-    archiveName=$(basename $biosFile | sed 's/_sign.*//')
+      archiveName=$(basename $biosFile | sed 's/_sign.*//')
 
-    mkdir -p $out
-    cp "$biosFile" .
-    gcab -c $out/"$archiveName".cab SteamDeckBIOS.metainfo.xml "$filename"
-  done
-''
+      mkdir -p $out
+      cp "$biosFile" .
+      gcab -c $out/"$archiveName".cab SteamDeckBIOS.metainfo.xml "$filename"
+    done
+  ''

--- a/pkgs/jupiter-hw-support/default.nix
+++ b/pkgs/jupiter-hw-support/default.nix
@@ -1,28 +1,33 @@
-{ lib
-, stdenv
-, callPackage
-, resholve
-, bash
-, coreutils
-, e2fsprogs
-, exfatprogs
-, f3
-, findutils
-, gawk
-, gnugrep
-, gnused
-, jq
-, parted
-, procps
-, systemd
-, util-linux
+{
+  lib,
+  stdenv,
+  callPackage,
+  resholve,
+  bash,
+  coreutils,
+  e2fsprogs,
+  exfatprogs,
+  f3,
+  findutils,
+  gawk,
+  gnugrep,
+  gnused,
+  jq,
+  parted,
+  procps,
+  systemd,
+  util-linux,
 }:
 
 let
   src = callPackage ./src.nix { };
 
   solution = {
-    scripts = [ "bin/*" "lib/hwsupport/*.sh" "lib/hwsupport/common-functions" ];
+    scripts = [
+      "bin/*"
+      "lib/hwsupport/*.sh"
+      "lib/hwsupport/common-functions"
+    ];
     interpreter = "${bash}/bin/bash";
     inputs = [
       coreutils

--- a/pkgs/jupiter-hw-support/firmware.nix
+++ b/pkgs/jupiter-hw-support/firmware.nix
@@ -1,31 +1,34 @@
-{ lib
-, stdenv
-, callPackage
-, autoPatchelfHook
-, makeWrapper
-, writeShellScript
-, python3
-, util-linuxMinimal
+{
+  lib,
+  stdenv,
+  callPackage,
+  autoPatchelfHook,
+  makeWrapper,
+  writeShellScript,
+  python3,
+  util-linuxMinimal,
 
-# jupiter-biosupdate
-, libkrb5
-, zlib
-, coreutils
-, gawk
-, dmidecode
-, jq
+  # jupiter-biosupdate
+  libkrb5,
+  zlib,
+  coreutils,
+  gawk,
+  dmidecode,
+  jq,
 
-, efiSysMountPoint ? "/boot"
+  efiSysMountPoint ? "/boot",
 }:
 
 let
   src = callPackage ./src.nix { };
-  pythonEnv = python3.withPackages (py: with py; [
-    crcmod
-    click
-    progressbar2
-    hid
-  ]);
+  pythonEnv = python3.withPackages (
+    py: with py; [
+      crcmod
+      click
+      progressbar2
+      hid
+    ]
+  );
 
   # Very ugly wrapper to work around the hardcoded ESP path
   h2offtWrapper = writeShellScript "h2offt-wrapper" ''
@@ -98,7 +101,14 @@ stdenv.mkDerivation {
     sed -i "s|/usr/share/jupiter_bios_updater/h2offt|$h2offt_nixos|g" $out/bin/jupiter-biosupdate
     sed -i "s|/usr/|$out/|g" $out/bin/jupiter-biosupdate
     wrapProgram $out/bin/jupiter-biosupdate \
-      --prefix PATH : ${lib.makeBinPath [ coreutils dmidecode gawk jq ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          coreutils
+          dmidecode
+          gawk
+          jq
+        ]
+      }
 
     cp usr/bin/jupiter-initial-firmware-update $out/bin
     sed -i "s|/usr/|$out/|g" $out/bin/jupiter-initial-firmware-update
@@ -107,13 +117,23 @@ stdenv.mkDerivation {
     cp usr/bin/jupiter-controller-update $out/bin
     sed -i "s|/usr/|$out/|g" $out/bin/jupiter-controller-update
     wrapProgram $out/bin/jupiter-controller-update \
-      --prefix PATH : ${lib.makeBinPath [ jq pythonEnv ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          pythonEnv
+        ]
+      }
 
     mkdir -p $out/libexec
     makeShellWrapper \
       $out/share/jupiter_controller_fw_updater/d20bootloader.py \
       $out/libexec/d20bootloader \
-      --prefix PATH : ${lib.makeBinPath [ jq pythonEnv ]}
+      --prefix PATH : ${
+        lib.makeBinPath [
+          jq
+          pythonEnv
+        ]
+      }
 
     pushd $out/share/jupiter_bios_updater
     # Upstream comment:

--- a/pkgs/jupiter-hw-support/polkit-helpers.nix
+++ b/pkgs/jupiter-hw-support/polkit-helpers.nix
@@ -18,7 +18,7 @@
 let
   src = callPackage ./src.nix { };
 
-  solution = {      
+  solution = {
     scripts = [ "bin/steamos-polkit-helpers/*" ];
     interpreter = "${bash}/bin/bash";
     inputs = [
@@ -53,7 +53,7 @@ let
       "cannot:${systemd}/bin/systemd-cat"
     ];
     fake = {
-      external = ["pkexec"];
+      external = [ "pkexec" ];
     };
     fix = {
       "/usr/bin/jupiter-biosupdate" = true;
@@ -73,7 +73,8 @@ let
       "/usr/lib/hwsupport/jupiter-amp-control" = true;
     };
   };
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "steamos-polkit-helpers";
 
   inherit src;
@@ -81,7 +82,7 @@ in stdenv.mkDerivation {
 
   patchPhase = ''
     runHook prePatch
-  
+
     substituteInPlace usr/share/polkit-1/actions/org.valve.steamos.policy --replace-fail /usr $out
 
     runHook postPatch

--- a/pkgs/jupiter-hw-support/src.nix
+++ b/pkgs/jupiter-hw-support/src.nix
@@ -1,8 +1,8 @@
-{ 
-  stdenv, 
-  fetchFromGitHub, 
-  replaceVars, 
-  jovian-steam-protocol-handler, 
+{
+  stdenv,
+  fetchFromGitHub,
+  replaceVars,
+  jovian-steam-protocol-handler,
   systemd,
 }:
 

--- a/pkgs/jupiter-hw-support/theme.nix
+++ b/pkgs/jupiter-hw-support/theme.nix
@@ -1,7 +1,8 @@
-{ lib
-, stdenv
-, callPackage
-, xorg
+{
+  lib,
+  stdenv,
+  callPackage,
+  xorg,
 }:
 
 let

--- a/pkgs/linux-firmware/default.nix
+++ b/pkgs/linux-firmware/default.nix
@@ -1,6 +1,6 @@
 { linux-firmware, fetchFromGitHub }:
 
-linux-firmware.overrideAttrs(_: rec {
+linux-firmware.overrideAttrs (_: rec {
   version = "20250731.1";
 
   src = fetchFromGitHub {

--- a/pkgs/linux-jovian/default.nix
+++ b/pkgs/linux-jovian/default.nix
@@ -1,4 +1,9 @@
-{ lib, fetchFromGitHub, buildLinux, ... } @ args:
+{
+  lib,
+  fetchFromGitHub,
+  buildLinux,
+  ...
+}@args:
 
 let
   inherit (lib) versions;
@@ -7,177 +12,181 @@ let
   vendorVersion = "valve1";
   hash = "sha256-H8ANgnTu/SKewqhwu2W1W+wNAm7ICsN44YIu9L/mjSg=";
 in
-buildLinux (args // rec {
-  version = "${kernelVersion}-${vendorVersion}";
+buildLinux (
+  args
+  // rec {
+    version = "${kernelVersion}-${vendorVersion}";
 
-  # branchVersion needs to be x.y
-  extraMeta.branch = versions.majorMinor version;
+    # branchVersion needs to be x.y
+    extraMeta.branch = versions.majorMinor version;
 
-  structuredExtraConfig = with lib.kernel; {
-    #
-    # From the downstream packaging
-    # -----------------------------
-    #
+    structuredExtraConfig = with lib.kernel; {
+      #
+      # From the downstream packaging
+      # -----------------------------
+      #
 
-    ##
-    ## Neptune stuff
-    ##
+      ##
+      ## Neptune stuff
+      ##
 
-    #
-    # Disable Radeon, SI and CIK support since not required for Vangogh GPU
-    #
-    DRM_AMDGPU_CIK = lib.mkForce no;
-    DRM_AMDGPU_SI = lib.mkForce no;
-    DRM_RADEON = no;
+      #
+      # Disable Radeon, SI and CIK support since not required for Vangogh GPU
+      #
+      DRM_AMDGPU_CIK = lib.mkForce no;
+      DRM_AMDGPU_SI = lib.mkForce no;
+      DRM_RADEON = no;
 
-    # Doesn't build on latest tag, not used in neptune hardware (?)
-    SND_SOC_CS35L36 = no;
-    # Update this to =y to workaround initialization issues and deadlocks when loaded as module
-    # The cs35l41 / acp5x drivers in EV2 fail IRQ initialization with this set to =y, changed back
-    SPI_AMD = module;
-    # Jovian: not a real option?
-    # CONFIG_I2C_AMD=m;
+      # Doesn't build on latest tag, not used in neptune hardware (?)
+      SND_SOC_CS35L36 = no;
+      # Update this to =y to workaround initialization issues and deadlocks when loaded as module
+      # The cs35l41 / acp5x drivers in EV2 fail IRQ initialization with this set to =y, changed back
+      SPI_AMD = module;
+      # Jovian: not a real option?
+      # CONFIG_I2C_AMD=m;
 
-    # Works around issues with the touchscreen driver
-    PINCTRL_AMD = yes;
+      # Works around issues with the touchscreen driver
+      PINCTRL_AMD = yes;
 
-    SND_SOC_AMD_ACP5x = module;
-    SND_SOC_AMD_VANGOGH_MACH = module;
-    SND_SOC_WM_ADSP = module;
-    SND_SOC_CS35L41 = module;
-    SND_SOC_CS35L41_SPI = module;
-    SND_SOC_NAU8821 = module;
-    SND_SOC_MAX98388 = module;
+      SND_SOC_AMD_ACP5x = module;
+      SND_SOC_AMD_VANGOGH_MACH = module;
+      SND_SOC_WM_ADSP = module;
+      SND_SOC_CS35L41 = module;
+      SND_SOC_CS35L41_SPI = module;
+      SND_SOC_NAU8821 = module;
+      SND_SOC_MAX98388 = module;
 
-    SND_SOC_AMD_ACP3x = no;
-    # Jovian: unused?
-    # SND_SOC_AMD_RV_RT5682_MACH = no;
-    SND_SOC_AMD_RENOIR = no;
-    # Jovian: unused?
-    # SND_SOC_AMD_RENOIR_MACH = no;
+      SND_SOC_AMD_ACP3x = no;
+      # Jovian: unused?
+      # SND_SOC_AMD_RV_RT5682_MACH = no;
+      SND_SOC_AMD_RENOIR = no;
+      # Jovian: unused?
+      # SND_SOC_AMD_RENOIR_MACH = no;
 
-    SND_AMD_ACP_CONFIG = module;
-    SND_SOC_AMD_ACP_COMMON = module;
-    # Jovian: unused?
-    # SND_SOC_AMD_ACP_PDM = no;
-    # SND_SOC_AMD_ACP_I2S = no;
-    # SND_SOC_AMD_ACP_PCM = no;
-    SND_SOC_AMD_ACP_PCI = no;
-    SND_AMD_ASOC_RENOIR = no;
-    SND_AMD_ASOC_REMBRANDT = no;
-    SND_SOC_AMD_MACH_COMMON = module;
-    SND_SOC_AMD_LEGACY_MACH = no;
+      SND_AMD_ACP_CONFIG = module;
+      SND_SOC_AMD_ACP_COMMON = module;
+      # Jovian: unused?
+      # SND_SOC_AMD_ACP_PDM = no;
+      # SND_SOC_AMD_ACP_I2S = no;
+      # SND_SOC_AMD_ACP_PCM = no;
+      SND_SOC_AMD_ACP_PCI = no;
+      SND_AMD_ASOC_RENOIR = no;
+      SND_AMD_ASOC_REMBRANDT = no;
+      SND_SOC_AMD_MACH_COMMON = module;
+      SND_SOC_AMD_LEGACY_MACH = no;
 
-    SND_SOC_AMD_SOF_MACH = module;
-    SND_SOC_AMD_RPL_ACP6x = no;
+      SND_SOC_AMD_SOF_MACH = module;
+      SND_SOC_AMD_RPL_ACP6x = no;
 
-    SND_SOC_SOF = module;
-    SND_SOC_SOF_PROBE_WORK_QUEUE = yes;
-    SND_SOC_SOF_IPC3 = yes;
-    # Jovian: renamed from _INTEL_
-    # https://github.com/Jovian-Experiments/linux/commit/e31b20c2f0c2e561e7b1bf671fe38bd5d83a496f
-    SND_SOC_SOF_IPC4 = yes;
+      SND_SOC_SOF = module;
+      SND_SOC_SOF_PROBE_WORK_QUEUE = yes;
+      SND_SOC_SOF_IPC3 = yes;
+      # Jovian: renamed from _INTEL_
+      # https://github.com/Jovian-Experiments/linux/commit/e31b20c2f0c2e561e7b1bf671fe38bd5d83a496f
+      SND_SOC_SOF_IPC4 = yes;
 
-    SND_SOC_SOF_AMD_TOPLEVEL = module;
-    SND_SOC_SOF_AMD_COMMON = module;
-    SND_SOC_SOF_AMD_RENOIR = no;
-    SND_SOC_SOF_AMD_REMBRANDT = no;
-    SND_SOC_SOF_AMD_VANGOGH = module;
+      SND_SOC_SOF_AMD_TOPLEVEL = module;
+      SND_SOC_SOF_AMD_COMMON = module;
+      SND_SOC_SOF_AMD_RENOIR = no;
+      SND_SOC_SOF_AMD_REMBRANDT = no;
+      SND_SOC_SOF_AMD_VANGOGH = module;
 
-    # Steam Deck HID driver
-    HID_STEAM = module;
-    STEAM_FF = yes;
+      # Steam Deck HID driver
+      HID_STEAM = module;
+      STEAM_FF = yes;
 
-    # Enable Ambient Light Sensor
-    LTRF216A = module;
+      # Enable Ambient Light Sensor
+      LTRF216A = module;
 
-    # Enable Steam Deck MFD driver, replaces Jupiter ACPI platform driver (CONFIG_JUPITER)
-    MFD_STEAMDECK = module;
-    EXTCON_STEAMDECK = module;
-    LEDS_STEAMDECK = module;
-    SENSORS_STEAMDECK = module;
+      # Enable Steam Deck MFD driver, replaces Jupiter ACPI platform driver (CONFIG_JUPITER)
+      MFD_STEAMDECK = module;
+      EXTCON_STEAMDECK = module;
+      LEDS_STEAMDECK = module;
+      SENSORS_STEAMDECK = module;
 
-    # Enable support for AMDGPU color calibration features
-    DRM_AMD_COLOR_STEAMDECK = yes;
+      # Enable support for AMDGPU color calibration features
+      DRM_AMD_COLOR_STEAMDECK = yes;
 
-    LENOVO_WMI_GAMEZONE = module;
-    LENOVO_WMI_TUNING = module;
-    LENOVO_LEGOS_HID = module;
+      LENOVO_WMI_GAMEZONE = module;
+      LENOVO_WMI_TUNING = module;
+      LENOVO_LEGOS_HID = module;
 
-    ZOTAC_ZONE_HID = module;
-    ZOTAC_ZONE_PLATFORM = module;
+      ZOTAC_ZONE_HID = module;
+      ZOTAC_ZONE_PLATFORM = module;
 
-    # Jovian: renamed
-    HID_ASUS_ALLY = module;
-    ASUS_ARMOURY = module;
+      # Jovian: renamed
+      HID_ASUS_ALLY = module;
+      ASUS_ARMOURY = module;
 
-    # PARAVIRT options have overhead, even on bare metal boots. They can cause
-    # spinlocks to not be inlined as well. Either way, we don't intend to run this
-    # kernel as a guest, so this also clears out a whole bunch of
-    # virtualization-specific drivers.
-    HYPERVISOR_GUEST = lib.mkForce no;
+      # PARAVIRT options have overhead, even on bare metal boots. They can cause
+      # spinlocks to not be inlined as well. Either way, we don't intend to run this
+      # kernel as a guest, so this also clears out a whole bunch of
+      # virtualization-specific drivers.
+      HYPERVISOR_GUEST = lib.mkForce no;
 
-    # Disable some options enabled in ArchLinux 6.1.12-arch1 config
-    # Jovian: we do have Rust, and we can't lie about it
-    # HAVE_RUST = no;
-  
-    # This has been disabled upstream since 6.11.8-arch1
-    # See: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/commit/1a06ca984333093fb12cbbff275da31fa2bc5f6c
-    ZSWAP_DEFAULT_ON = yes;
+      # Disable some options enabled in ArchLinux 6.1.12-arch1 config
+      # Jovian: we do have Rust, and we can't lie about it
+      # HAVE_RUST = no;
 
-    # Build as module to experiment with toggling
-    TCG_TPM = module;
+      # This has been disabled upstream since 6.11.8-arch1
+      # See: https://gitlab.archlinux.org/archlinux/packaging/packages/linux/-/commit/1a06ca984333093fb12cbbff275da31fa2bc5f6c
+      ZSWAP_DEFAULT_ON = yes;
 
-    # Per Colin at Quectel
-    CFG80211_CERTIFICATION_ONUS = yes;
-    ATH_REG_DYNAMIC_USER_REG_HINTS = yes;
+      # Build as module to experiment with toggling
+      TCG_TPM = module;
 
-    # Enable ath11k tracing for wifi debugging
-    ATH11K_TRACING = yes;
+      # Per Colin at Quectel
+      CFG80211_CERTIFICATION_ONUS = yes;
+      ATH_REG_DYNAMIC_USER_REG_HINTS = yes;
 
-    # Disable simple-framebuffer to fix logo regression
-    SYSFB_SIMPLEFB = lib.mkForce no;
+      # Enable ath11k tracing for wifi debugging
+      ATH11K_TRACING = yes;
 
-    # Enable Extensible Scheduling Class
-    SCHED_CLASS_EXT = yes;
+      # Disable simple-framebuffer to fix logo regression
+      SYSFB_SIMPLEFB = lib.mkForce no;
 
-    # Disable call depth tracking speculative execution vulnerability mitigation
-    # Jovian: renamed
-    MITIGATION_CALL_DEPTH_TRACKING = no;
+      # Enable Extensible Scheduling Class
+      SCHED_CLASS_EXT = yes;
 
-    # Xbox GIP driver
-    JOYSTICK_XBOX_GIP = module;
-    JOYSTICK_XBOX_GIP_FF = yes;
-    JOYSTICK_XBOX_GIP_LEDS = yes;
+      # Disable call depth tracking speculative execution vulnerability mitigation
+      # Jovian: renamed
+      MITIGATION_CALL_DEPTH_TRACKING = no;
 
-    # Jovian: fix fallout from the vendor-set options
-    DRM_AMD_DC_SI = lib.mkForce (option no);
-    DRM_HYPERV = lib.mkForce (option no);
-    FB_HYPERV = lib.mkForce (option no);
-    INTEL_TDX_GUEST = lib.mkForce (option no);
-    KVM_GUEST = lib.mkForce (option no);
-    MOUSE_PS2_VMMOUSE = lib.mkForce (option no);
-    PARAVIRT_TIME_ACCOUNTING = lib.mkForce (option no);
-    TDX_GUEST_DRIVER = lib.mkForce (option no);
-  };
+      # Xbox GIP driver
+      JOYSTICK_XBOX_GIP = module;
+      JOYSTICK_XBOX_GIP_FF = yes;
+      JOYSTICK_XBOX_GIP_LEDS = yes;
 
-  src = fetchFromGitHub {
-    owner = "Jovian-Experiments";
-    repo = "linux";
-    rev = version;
-    inherit hash;
+      # Jovian: fix fallout from the vendor-set options
+      DRM_AMD_DC_SI = lib.mkForce (option no);
+      DRM_HYPERV = lib.mkForce (option no);
+      FB_HYPERV = lib.mkForce (option no);
+      INTEL_TDX_GUEST = lib.mkForce (option no);
+      KVM_GUEST = lib.mkForce (option no);
+      MOUSE_PS2_VMMOUSE = lib.mkForce (option no);
+      PARAVIRT_TIME_ACCOUNTING = lib.mkForce (option no);
+      TDX_GUEST_DRIVER = lib.mkForce (option no);
+    };
 
-    # Sometimes the vendor doesn't update the EXTRAVERSION tag.
-    # Let's fix it up in post.
-    # ¯\_(ツ)_/¯
-    # Also, `postPatch` on the kernel doesn't compose in `buildLinux`.
-    # ¯\_(ツ)_/¯
-    postFetch = ''
-      (
-      echo ":: Fixing-up EXTRAVERSION with actual tag"
-      cd $out
-      sed -i -e 's/^EXTRAVERSION =.*/EXTRAVERSION = -${vendorVersion}/g' Makefile
-      )
-    '';
-  };
-} // (args.argsOverride or { }))
+    src = fetchFromGitHub {
+      owner = "Jovian-Experiments";
+      repo = "linux";
+      rev = version;
+      inherit hash;
+
+      # Sometimes the vendor doesn't update the EXTRAVERSION tag.
+      # Let's fix it up in post.
+      # ¯\_(ツ)_/¯
+      # Also, `postPatch` on the kernel doesn't compose in `buildLinux`.
+      # ¯\_(ツ)_/¯
+      postFetch = ''
+        (
+        echo ":: Fixing-up EXTRAVERSION with actual tag"
+        cd $out
+        sed -i -e 's/^EXTRAVERSION =.*/EXTRAVERSION = -${vendorVersion}/g' Makefile
+        )
+      '';
+    };
+  }
+  // (args.argsOverride or { })
+)

--- a/pkgs/mesa-radeonsi-jupiter/default.nix
+++ b/pkgs/mesa-radeonsi-jupiter/default.nix
@@ -1,4 +1,4 @@
-{ 
+{
   lib,
   stdenv,
   llvmPackages,
@@ -23,17 +23,18 @@ stdenv.mkDerivation {
   # Jovian: tell Mesa where to find libclang
   patches = [ ./opencl.patch ];
 
-  inherit (mesa) 
+  inherit (mesa)
     buildInputs
     nativeBuildInputs
     propagatedBuildInputs
     # inherit fixups so we get correct paths in EGL driver/Vulkan layer manifests
-    postFixup;
+    postFixup
+    ;
 
   separateDebugInfo = true;
 
   mesonAutoFeatures = "auto";
-  
+
   # See https://github.com/Jovian-Experiments/PKGBUILDs-mirror/blob/jupiter-main/mesa-radeonsi/PKGBUILD
   mesonFlags = [
     "-D android-libbacktrace=disabled"

--- a/pkgs/mesa-radv-jupiter/default.nix
+++ b/pkgs/mesa-radv-jupiter/default.nix
@@ -1,8 +1,13 @@
-{ stdenv, mesa, fetchFromGitHub }:
+{
+  stdenv,
+  mesa,
+  fetchFromGitHub,
+}:
 let
   version = "25.2.0";
   jupiterVersion = "steamos-25.6.0";
-in stdenv.mkDerivation {
+in
+stdenv.mkDerivation {
   pname = "mesa";
   version = "${version}.${jupiterVersion}";
 

--- a/pkgs/powerbuttond/default.nix
+++ b/pkgs/powerbuttond/default.nix
@@ -8,7 +8,7 @@
   udev,
   jovian-steam-protocol-handler,
 }:
-stdenv.mkDerivation(finalAttrs: {
+stdenv.mkDerivation (finalAttrs: {
   pname = "powerbuttond";
   version = "3.3";
 
@@ -34,8 +34,11 @@ stdenv.mkDerivation(finalAttrs: {
       --replace-fail /usr/lib/hwsupport/steamos-powerbuttond $out/bin/steamos-powerbuttond
   '';
 
-  nativeBuildInputs = [pkg-config];
-  buildInputs = [libevdev udev];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [
+    libevdev
+    udev
+  ];
 
   makeFlags = [
     "DESTDIR=$(out)"

--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -1,18 +1,19 @@
 # A wrapped version of Steam with shims to satisfy the SteamOS-only
 # dependencies of the Steam Deck UI
 
-{ writeShellScriptBin
-, dmidecode
-, jovian-stubs
-, steam
+{
+  writeShellScriptBin,
+  dmidecode,
+  jovian-stubs,
+  steam,
 
-# We need to add this flag when Steam is started directly (e.g., desktop mode)
-# so we have the correct client version. This is important even for desktop
-# use because only the Steam Deck branch of the client has the new on-screen
-# keyboard that's summoned with STEAM + X.
-, platformArgs ? "-steamos3 -steampal -steamdeck"
-, ...
-} @ args:
+  # We need to add this flag when Steam is started directly (e.g., desktop mode)
+  # so we have the correct client version. This is important even for desktop
+  # use because only the Steam Deck branch of the client has the new on-screen
+  # keyboard that's summoned with STEAM + X.
+  platformArgs ? "-steamos3 -steampal -steamdeck",
+  ...
+}@args:
 
 let
   extraArgs = builtins.removeAttrs args [
@@ -49,25 +50,31 @@ let
     systemctl stop --user gamescope-session
   '';
 
-  wrappedSteam = steam.override (extraArgs // {
-    extraPkgs = pkgs: (if args ? extraPkgs then args.extraPkgs pkgs else [ ]) ++ [
-      dmidecode
-      jovian-stubs
-      sessionSwitcher
+  wrappedSteam = steam.override (
+    extraArgs
+    // {
+      extraPkgs =
+        pkgs:
+        (if args ? extraPkgs then args.extraPkgs pkgs else [ ])
+        ++ [
+          dmidecode
+          jovian-stubs
+          sessionSwitcher
 
-      # FIXME: figure out how to fix pkexec (needs SUID in fhsenv, see https://github.com/NixOS/nixpkgs/issues/69338) 
-      # and readd steamos-polkit-helpers
-    ];
-    extraProfile = (args.extraProfile or "") + ''
-      export PATH=${jovian-stubs}/bin:$PATH
-    '';
+          # FIXME: figure out how to fix pkexec (needs SUID in fhsenv, see https://github.com/NixOS/nixpkgs/issues/69338)
+          # and readd steamos-polkit-helpers
+        ];
+      extraProfile = (args.extraProfile or "") + ''
+        export PATH=${jovian-stubs}/bin:$PATH
+      '';
 
-    # Force using host /tmp so gamescope-session can find the magic files
-    extraBwrapArgs = (args.extraBwrapArgs or [ ]) ++ [
-      "--bind /tmp /tmp"
-    ];
+      # Force using host /tmp so gamescope-session can find the magic files
+      extraBwrapArgs = (args.extraBwrapArgs or [ ]) ++ [
+        "--bind /tmp /tmp"
+      ];
 
-    extraArgs = (args.extraArgs or "") + " " + platformArgs;
-  });
+      extraArgs = (args.extraArgs or "") + " " + platformArgs;
+    }
+  );
 in
 wrappedSteam

--- a/pkgs/steam-jupiter/unwrapped.nix
+++ b/pkgs/steam-jupiter/unwrapped.nix
@@ -11,7 +11,8 @@ let
     url = "https://steamdeck-packages.steamos.cloud/archlinux-mirror/sources/jupiter-main/steam-jupiter-stable-${bootstrapVersion}.src.tar.gz";
     hash = "sha256-Gh6QsjqxQbBMbCGAnZbqE/uzZyBG1zE43Kz5m9MRNq4=";
   };
-in steam-unwrapped'.overrideAttrs (old: {
+in
+steam-unwrapped'.overrideAttrs (old: {
   pname = "steam-jupiter-unwrapped";
 
   postInstall = (old.postInstall or "") + ''
@@ -19,6 +20,6 @@ in steam-unwrapped'.overrideAttrs (old: {
     tar xvf ${bundle}
     cp steam-jupiter-stable/steam_jupiter_stable_bootstrapped_*.tar.xz $out/lib/steam/bootstraplinux_ubuntu12_32.tar.xz
   '';
-  
+
   passthru = { inherit bootstrapVersion; };
 })

--- a/pkgs/steam_notif_daemon/default.nix
+++ b/pkgs/steam_notif_daemon/default.nix
@@ -27,10 +27,17 @@ stdenv.mkDerivation (finalAttrs: {
     })
   ];
 
-  mesonFlags = ["-Dsd-bus-provider=libsystemd"];
+  mesonFlags = [ "-Dsd-bus-provider=libsystemd" ];
 
-  nativeBuildInputs = [pkg-config meson ninja];
-  buildInputs = [systemd curl];
+  nativeBuildInputs = [
+    pkg-config
+    meson
+    ninja
+  ];
+  buildInputs = [
+    systemd
+    curl
+  ];
 
   meta = with lib; {
     description = "Steam notification daemon";

--- a/pkgs/steamdeck-dsp/default.nix
+++ b/pkgs/steamdeck-dsp/default.nix
@@ -1,15 +1,16 @@
-{ stdenv
-, lib
-, fetchFromGitHub
-, boost
-, lv2
-, faust2lv2
-, rnnoise-plugin
-, which
-, resholve
-, bash
-, coreutils
-, dmidecode
+{
+  stdenv,
+  lib,
+  fetchFromGitHub,
+  boost,
+  lv2,
+  faust2lv2,
+  rnnoise-plugin,
+  which,
+  resholve,
+  bash,
+  coreutils,
+  dmidecode,
 }:
 
 let
@@ -29,7 +30,7 @@ let
       dmidecode
     ];
   };
-  self = stdenv.mkDerivation(finalAttrs: {
+  self = stdenv.mkDerivation (finalAttrs: {
     pname = "steamdeck-dsp";
     version = "0.69";
 
@@ -77,7 +78,7 @@ let
       ${resholve.phraseSolution "wireplumber-hwconfig" wireplumber-hwconfig-solution}
 
       for pkg in pipewire wireplumber; do
-        for i in $(find $out/share/$pkg/hardware-profiles/* -type f -printf "%P\n" | sort | uniq); do 
+        for i in $(find $out/share/$pkg/hardware-profiles/* -type f -printf "%P\n" | sort | uniq); do
           mkdir -p $(dirname "$out/share/$pkg/$i")
           ln -s /run/$pkg/$i $out/share/$pkg/$i
         done
@@ -97,4 +98,5 @@ let
       license = lib.licenses.gpl3;
     };
   });
-in self
+in
+self

--- a/pkgs/steamos-manager/default.nix
+++ b/pkgs/steamos-manager/default.nix
@@ -35,9 +35,8 @@ rustPlatform.buildRustPackage rec {
   # tests assume Steam Deck hardware and FHS paths
   doCheck = false;
 
-  patches = [ 
-    (replaceVars ./hardcode-paths.patch
-    {
+  patches = [
+    (replaceVars ./hardcode-paths.patch {
       stubs = jovian-stubs;
       steamDeckFirmware = steamdeck-firmware;
       jupiterDockUpdaterBin = jupiter-dock-updater-bin;

--- a/pkgs/wakehook/default.nix
+++ b/pkgs/wakehook/default.nix
@@ -16,8 +16,8 @@ stdenv.mkDerivation (finalAttrs: {
     hash = "sha256-KtwD+7BYj654JD28DWAr2jFkqTkM0NraSFivO6UXIYg=";
   };
 
-  nativeBuildInputs = [pkg-config];
-  buildInputs = [systemd];
+  nativeBuildInputs = [ pkg-config ];
+  buildInputs = [ systemd ];
 
   installPhase = ''
     runHook preInstall

--- a/pkgs/wireplumber/default.nix
+++ b/pkgs/wireplumber/default.nix
@@ -1,6 +1,6 @@
 { wireplumber', fetchFromGitHub }:
 wireplumber'.overrideAttrs (_: {
-  version = "0.5.10";
+  version = "0.5.10-1.3";
 
   src = fetchFromGitHub {
     owner = "Jovian-Experiments";

--- a/pkgs/wireplumber/default.nix
+++ b/pkgs/wireplumber/default.nix
@@ -1,5 +1,5 @@
 { wireplumber', fetchFromGitHub }:
-wireplumber'.overrideAttrs(_: {
+wireplumber'.overrideAttrs (_: {
   version = "0.5.10";
 
   src = fetchFromGitHub {


### PR DESCRIPTION
Run treefmt on packages to make it easier on contributors who are used to the modern nixpkgs format.