### PR TITLE
fix: migrate logind extraConfig to attribute

### DIFF
--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -94,9 +94,9 @@ in
       services.displayManager.sessionPackages = [ pkgs.gamescope-session ];
 
       # Conflicts with powerbuttond
-      services.logind.extraConfig = ''
-        HandlePowerKey=ignore
-      '';
+      services.logind.settings.Login = {
+        HandlePowerKey = "ignore";
+      };
 
       services.udev.packages = [
         pkgs.powerbuttond


### PR DESCRIPTION
There is a breaking change that landed in unstable from this PR https://github.com/NixOS/nixpkgs/pull/435407