### PR TITLE
jovian-stubs: check for new kernel in steamos-update

### DIFF
--- a/pkgs/jovian-stubs/steamos-update
+++ b/pkgs/jovian-stubs/steamos-update
@@ -5,4 +5,7 @@
 # 1 - update error
 # 7 - no update available
 # 8 - need reboot
+
+[ "$(readlink /run/booted-system/kernel)" != "$(readlink /nix/var/nix/profiles/system/kernel)" ] && exit 8
+
 exit 7


### PR DESCRIPTION
This is the most generic check we have for when NixOS would boot into a newer kernel on the next reboot.

Untested.