### PR TITLE
modules/steam/autostart: warn on desktopSession with no autoStart

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -54,6 +54,14 @@ in
   };
 
   config = mkIf cfg.enable (mkMerge [
+    {
+      warnings = lib.optional (!cfg.autoStart && cfg.desktopSession != null) ''
+        jovian.steam.desktopSession has no effect if jovian.steam.autoStart is disabled.
+
+        Either enable jovian.steam.autoStart, or remove the desktopSession setting.
+      '';
+    }
+
     (mkIf cfg.autoStart {
       warnings = lib.optional (cfg.desktopSession == null) ''
         jovian.steam.desktopSession is unset.


### PR DESCRIPTION
Add validation to warn users when `jovian.steam.desktopSession` is configured but `jovian.steam.autoStart` is disabled, since the desktopSession option only has an effect when autoStart is enabled.

I hit this and was confused by how SteamOS kept taking me back to the switcher screen instead of dropping me in Niri.

I suppose an alternative approach would be to:

1. Convert `autoStart` into an attrset (with an `enable` field)
2. Embed `desktopSession` inside `autoStart`
3. Use `mkRenamedOptionModule` to ensure we're backwards compatible

Let me know if you prefer the new option structure and I can update this PR or handle it in a follow-up.
