### PR TITLE
steam-jupiter: fixed order of extra arguments

### DIFF
--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -58,16 +58,16 @@ let
       # FIXME: figure out how to fix pkexec (needs SUID in fhsenv, see https://github.com/NixOS/nixpkgs/issues/69338) 
       # and readd steamos-polkit-helpers
     ];
-    extraProfile = (args.extraProfile or "") + ''
+    extraProfile = ''
       export PATH=${jovian-stubs}/bin:$PATH
-    '';
+    '' + (args.extraProfile or "");
 
     # Force using host /tmp so gamescope-session can find the magic files
     extraBwrapArgs = [
       "--bind /tmp /tmp"
     ] ++ (args.extraBwrapArgs or [ ]);
 
-    extraArgs = (args.extraArgs or "") + " " + platformArgs;
+    extraArgs = platformArgs + " " + (args.extraArgs or "");
   });
 in
 wrappedSteam

--- a/pkgs/steam-jupiter/fhsenv.nix
+++ b/pkgs/steam-jupiter/fhsenv.nix
@@ -6,10 +6,10 @@
 , jovian-stubs
 , steam
 
-# We need to add this flag when Steam is started directly (e.g., desktop mode)
-# so we have the correct client version. This is important even for desktop
-# use because only the Steam Deck branch of the client has the new on-screen
-# keyboard that's summoned with STEAM + X.
+  # We need to add this flag when Steam is started directly (e.g., desktop mode)
+  # so we have the correct client version. This is important even for desktop
+  # use because only the Steam Deck branch of the client has the new on-screen
+  # keyboard that's summoned with STEAM + X.
 , platformArgs ? "-steamdeck"
 , ...
 } @ args:
@@ -63,9 +63,9 @@ let
     '';
 
     # Force using host /tmp so gamescope-session can find the magic files
-    extraBwrapArgs = (args.extraBwrapArgs or [ ]) ++ [
+    extraBwrapArgs = [
       "--bind /tmp /tmp"
-    ];
+    ] ++ (args.extraBwrapArgs or [ ]);
 
     extraArgs = (args.extraArgs or "") + " " + platformArgs;
   });


### PR DESCRIPTION
When extra arguments are supplied by the users, they should have gone at the end, as they should be higher priority (overriding the base ones). 
Important for fixes like https://github.com/ValveSoftware/gamescope/issues/1133#issuecomment-2057923547