### PR TITLE
modules/steam/gamescope: options to pass flags to gamescope

### DIFF
--- a/modules/steam/default.nix
+++ b/modules/steam/default.nix
@@ -11,6 +11,7 @@ in
     ./steam.nix
     ./autostart.nix
     ./environment.nix
+    ./gamescope.nix
     ./updater.nix
   ];
   options = {

--- a/modules/steam/gamescope.nix
+++ b/modules/steam/gamescope.nix
@@ -1,0 +1,59 @@
+{ config, lib, ... }:
+
+let
+  inherit (lib)
+    concatStringsSep
+    mkIf
+    mkOption
+    optionals
+    toShellVar
+    types
+  ;
+
+  cfg = config.jovian.steam;
+in
+{
+  options = {
+    jovian.steam.gamescope = {
+      preferOutputs = mkOption {
+        type = types.listOf types.str;
+        default = [ "*" "eDP-1" ];
+        description = ''
+          List of preferred outputs (monitors) for gamescope. gamescope will
+          start on the *first* matching monitor.
+
+          The default is to prefer *any* monitor that is not the internal
+          Steam Deck display (`eDP-1`).
+
+          You can find the set of available outputs using tools like `xrandr` (X11)
+          or `wlr-randr` (Wayland).
+        '';
+        example = [ "HDMI-1" "DP-2" ];
+      };
+      extraArgs = mkOption {
+        type = types.listOf types.str;
+        default = [];
+        description = ''
+          Additional arguments to pass as-is to the gamescope instance as flags.
+
+          You can find the full set of available flags by running:
+
+          ```shell
+          $ gamescope --help
+          ```
+        '';
+        example = [ "--mangoapp" "-r" "120" ];
+      };
+    };
+  };
+
+  config = mkIf cfg.enable {
+    environment.etc."xdg/gamescope-session/environment" = {
+      text = let
+        args = (optionals (cfg.gamescope.preferOutputs != []) [
+          "-O" (concatStringsSep "," cfg.gamescope.preferOutputs)
+        ]) ++ cfg.gamescope.extraArgs;
+      in lib.mkAfter (toShellVar "JOVIAN_GAMESCOPE_ARGS" args);
+    };
+  };
+}

--- a/pkgs/gamescope-session/default.nix
+++ b/pkgs/gamescope-session/default.nix
@@ -123,6 +123,7 @@ in stdenv.mkDerivation(finalAttrs: {
 
   patches = [
     ./environment.patch
+    ./gamescope-args.patch
     (replaceVars ./portals.patch {
       gamescope-portals = symlinkJoin {
         name = "gamescope-portals";

--- a/pkgs/gamescope-session/gamescope-args.patch
+++ b/pkgs/gamescope-session/gamescope-args.patch
@@ -1,0 +1,22 @@
+--- a/gamescope-session
++++ b/gamescope-session
+@@ -254,6 +254,12 @@
+ # Spawned in parallel to read values from gamescope
+ (read_gamescope_env &)
+ 
++# Jovian: Load custom arguments
++GAMESCOPE_ARGS=()
++if declare -p JOVIAN_GAMESCOPE_ARGS &>/dev/null; then
++    GAMESCOPE_ARGS+=( "${JOVIAN_GAMESCOPE_ARGS[@]}" )
++fi
++
+ exec gamescope \
+ 	--generate-drm-mode fixed \
+ 	--xwayland-count 2 \
+@@ -263,5 +272,5 @@
+ 	--max-scale 2 \
+ 	--fade-out-duration 200 \
+ 	-e -R "$socket" -T "$stats" \
+-	-O '*',eDP-1 \
++	"${GAMESCOPE_ARGS[@]}" \
+ 


### PR DESCRIPTION
This is a new submodule that provides options to pass along flags to gamescope.

For now, I've specified a dedicated option for the `-O/--prefer-output` flag, which allows controlling which monitor gamescope starts on.

The default behavior is to prioritize any display (`*`) that is _not_ an internal display (`eDP-1`). I've carried over this default to the module option. My guess is that this default is geared towards the Steam Deck. Looking at the connector selection logic [here](https://github.com/ValveSoftware/gamescope/blob/fcc13418765312fd5c5c76333d30ef07cd536e22/src/Backends/DRMBackend.cpp#L1066), any display that is **not** passed in via the `-O` flag will get a default max priority.

Arbitrary gamescope flags can be passed via `extraArgs`. Note that any existing flags - including those set by the `gamescope-session` script itself - will be overridden if set via `extraArgs` as they are always be applied **last**. 

Basic verification: https://youtu.be/9rYkRGU5nLY

Tested:

```shell
$ nix eval --impure --expr '(import <nixpkgs> {}).lib.toShellVar "JOVIAN_GAMESCOPE_ARGS" [ "-O" "*,eDP-1" "--mangoapp" "-r" "120" ]'

"declare -a JOVIAN_GAMESCOPE_ARGS=(-O '*,eDP-1' --mangoapp -r 120)
```

Fixes #5.