### PR TITLE
fix: switch to desktop mode

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -9,6 +9,7 @@ let
     types
   ;
   cfg = config.jovian.steam;
+  dmcfg = config.services.displayManager;
 in
 {
   options = {
@@ -139,6 +140,20 @@ in
       };
 
       xdg.portal.configPackages = mkDefault [ pkgs.gamescope-session ];
+
+      # steamos-manager expects session .desktop files under /usr/share/{wayland-sessions,xsessions}
+      # and writes temporary session config to /etc/sddm.conf.d/. These paths are hardcoded in the
+      # steamos-manager binary. Create the directories and symlink the session files so that
+      # steamos-manager's ValidDesktopSessions and SwitchToDesktopMode D-Bus methods work correctly.
+      systemd.tmpfiles.rules = let
+        desktops = dmcfg.sessionData.desktops;
+      in [
+        # Symlink session .desktop files to where steamos-manager looks for them
+        "L+ /usr/share/wayland-sessions - - - - ${desktops}/share/wayland-sessions"
+        "L+ /usr/share/xsessions - - - - ${desktops}/share/xsessions"
+        # steamos-manager writes temporary session config here during SwitchToDesktopMode
+        "d /etc/sddm.conf.d 0755 root root -"
+      ];
     })
   ]);
 }

--- a/pkgs/jovian-greeter/greeter.py
+++ b/pkgs/jovian-greeter/greeter.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 # A minimal greetd greeter that runs a user's preferred session
 # in $HOME/.local/state/steamos-session-select
+# or /etc/sddm.conf.d/zzt-steamos-temp-login.conf (written by steamos-manager)
 
+import configparser
 import json
 import logging
 import os
@@ -17,6 +19,7 @@ from typing import cast, override
 from systemd.journal import JournalHandler
 
 DEFAULT_SESSION = 'gamescope-wayland'
+SDDM_TEMPORARY_CONFIG = Path('/etc/sddm.conf.d/zzt-steamos-temp-login.conf')
 
 class Session:
     TYPE: str = 'tty'
@@ -141,6 +144,7 @@ class Context:
         return self._find_sessions(sessions)
 
     def _consume_session(self) -> str | None:
+        # First, check the traditional session state file (written by steamos-session-select)
         res = subprocess.run(
             ['/run/wrappers/bin/jovian-consume-session'],
             stdin=subprocess.DEVNULL,
@@ -150,10 +154,35 @@ class Context:
         )
         next_session = res.stdout.decode('utf-8').strip()
 
-        if not next_session:
-            return None
+        if next_session:
+            return next_session
 
-        return next_session
+        # Fallback: check the SDDM temporary config written by steamos-manager.
+        # As of early 2026, the Steam client uses the steamos-manager D-Bus API
+        # (SwitchToDesktopMode) which writes an SDDM config file instead of calling
+        # steamos-session-select. Read and consume it here.
+        return self._consume_sddm_temporary_session()
+
+    def _consume_sddm_temporary_session(self) -> str | None:
+        try:
+            config = configparser.ConfigParser()
+            config.read(SDDM_TEMPORARY_CONFIG)
+            session = config.get('Autologin', 'Session', fallback=None)
+            if not session:
+                return None
+            # Strip .desktop suffix if present; session names are stored without it
+            if session.endswith('.desktop'):
+                session = session[:-len('.desktop')]
+            try:
+                SDDM_TEMPORARY_CONFIG.unlink()
+            except OSError as ex:
+                logging.warning("Cannot remove SDDM temporary config: %s", ex)
+            logging.info("Consumed SDDM temporary session: '%s'", session)
+            return session
+        except Exception as ex:
+            logging.debug("Failed to read SDDM temporary config", exc_info=ex)
+
+        return None
 
     def _find_sessions(self, sessions: list[str]) -> Session | None:
         for data_dir in self.xdg_data_dirs + [ '/usr/share' ]:


### PR DESCRIPTION
Fixes broken "switch to desktop" mode handling. Seems to be a new D-BUS API which Steam big picture mode is using now. Fully backwards compatible with previous versions of the Steam client.

This fix is pretty urgent as it breaks no matter the NixOS generation as Steam auto-updates. My system was broken for a while today. It was very confusing.


Open to comments!