### PR TITLE
fix: allow steamos-manager to override sddm config

### DIFF
--- a/modules/steam/autostart.nix
+++ b/modules/steam/autostart.nix
@@ -73,20 +73,25 @@ in
         to keep this behavior.
       '';
 
-
+      # Disable NixOS's autologin config generation.
+      # We put autologin config in sddm.conf.d instead so that steamos-manager's
+      # zzt-steamos-temp-login.conf can override the session on Switch to Desktop.
+      # (SDDM reads conf.d files alphabetically, so zzt > 00)
       services.displayManager = {
-        autoLogin = {
-          enable = true;
-          user = cfg.user;
-        };
-        sddm = {
-          enable = true;
-          autoLogin.relogin = true;
-        };
-        defaultSession = "gamescope-wayland";
+        autoLogin.enable = lib.mkForce false;
+        sddm.enable = true;
       };
 
-      # tell steamos-manager it's allowed to manage our session
+      environment.etc."sddm.conf.d/00-jovian-autologin.conf".text = ''
+        [Autologin]
+        User=${cfg.user}
+        Relogin=true
+        Session=gamescope-wayland.desktop
+      '';
+
+      # Sentinel file: tell steamos-manager it's allowed to manage our session
+      # Without it, the SessionManagement1 D-Bus interface
+      # (Switch to Desktop/Game Mode) is not registered.
       environment.etc."sddm.conf.d/steamos.conf".text = "";
 
       # Steam overrides this SOMETIMES seemingly for no reason

--- a/modules/steam/steam.nix
+++ b/modules/steam/steam.nix
@@ -87,6 +87,11 @@ in
         wantedBy = [ "gamescope-session.service" ];
       };
 
+      systemd.user.services.steamos-manager-session-cleanup = {
+        overrideStrategy = "asDropin";
+        wantedBy = [ "graphical-session.target" ];
+      };
+
       systemd.services.steamos-manager = {
         overrideStrategy = "asDropin";
         # FIXME: should probably be done upstream

--- a/pkgs/steamos-manager/default.nix
+++ b/pkgs/steamos-manager/default.nix
@@ -104,8 +104,12 @@ rustPlatform.buildRustPackage rec {
     install -m644 "data/system/com.steampowered.SteamOSManager1.conf" "$out/share/dbus-1/system.d/"
     install -m644 "data/system/steamos-manager.service" "$out/lib/systemd/system/"
 
+    install -d -m0755 "$out/lib/systemd/system/sddm.service.d/"
+    install -m644 "data/system/reset-oneshot-boot.conf" "$out/lib/systemd/system/sddm.service.d/"
+
     install -m644 "data/user/com.steampowered.SteamOSManager1.service" "$out/share/dbus-1/services/"
     install -m644 "data/user/steamos-manager.service" "$out/lib/systemd/user/"
+    install -m644 "data/user/steamos-manager-session-cleanup.service" "$out/lib/systemd/user/"
   '';
 
   postFixup = ''


### PR DESCRIPTION
`steamos-manager` creates a file `zzt-steamos-temp-login.conf` in order to temporarily override the sddm config in order to switch to desktop. But we were hard coding this into `sddm.conf`, we should've really be doing this in a seperate config in `sddm.conf.d` so that steamos-manager's config can override it when the user requests to switch to desktop.

This matches how it works on SteamOS.