### PR TITLE
gamescope: 3.16.21 -> 3.16.22

### DIFF
--- a/pkgs/gamescope/default.nix
+++ b/pkgs/gamescope/default.nix
@@ -7,13 +7,13 @@
 #       version shipped by the vendor, ensuring feature level is equivalent.
 
 gamescope'.overrideAttrs(old: rec {
-  version = "3.16.21";
+  version = "3.16.22";
 
   src = fetchFromGitHub {
     owner = "ValveSoftware";
     repo = "gamescope";
     rev = version;
     fetchSubmodules = true;
-    hash = "sha256-DjdmqIyLpEDmkXahpmPIdJtKtTBwqZY2uuUm45RjKTA=";
+    hash = "sha256-FuQkKguW00yI2w5nCctcxz7e1ZUKSWJOCIS1UMJzsMA=";
   };
 })


### PR DESCRIPTION
This fixes an issue where the *background recording* feature breaks audio for games.

Some games *really don't like that*, like for example *Super Hexagon*, which will crash reliably in that situation.

See https://github.com/ValveSoftware/gamescope/releases/tag/3.16.22