### PR TITLE
jovian-stubs: add missing stubs

### DIFF
--- a/pkgs/jovian-stubs/default.nix
+++ b/pkgs/jovian-stubs/default.nix
@@ -5,6 +5,7 @@ stdenv.mkDerivation {
   buildCommand = ''
     install -D -m 755 ${./steamos-factory-reset-config} $out/bin/steamos-factory-reset-config
     install -D -m 755 ${./steamos-firmware-update} $out/bin/steamos-firmware-update
+    install -D -m 755 ${./steamos-mandatory-update} $out/bin/steamos-mandatory-update
     install -D -m 755 ${./steamos-reboot} $out/bin/steamos-reboot
     install -D -m 755 ${./steamos-select-branch} $out/bin/steamos-select-branch
     install -D -m 755 ${./steamos-session-select} $out/bin/steamos-session-select

--- a/pkgs/jovian-stubs/steamos-mandatory-update
+++ b/pkgs/jovian-stubs/steamos-mandatory-update
@@ -1,0 +1,11 @@
+#!/bin/sh
+>&2 echo "[JOVIAN] $0: stub called with: $*"
+# Exit codes according to vendor:
+# 0 - update success
+# 1 - update error
+# 7 - no update available
+# 8 - need reboot
+
+[ "$(readlink /run/booted-system/kernel)" != "$(readlink /nix/var/nix/profiles/system/kernel)" ] && exit 8
+
+exit 7


### PR DESCRIPTION
Was doing my own debugging for a steamos-like setup and noticed some missing stubs.

`steamos-mandatory-update` is a new command that newer steam clients. I put it to mirror `steamos-update`'s logic.

I'm not 100% if this is the right approach? Let me know!