### PR TITLE
decky-loader: build with pnpm 10

### DIFF
--- a/pkgs/decky-loader/default.nix
+++ b/pkgs/decky-loader/default.nix
@@ -1,7 +1,7 @@
 { lib
 , fetchFromGitHub
 , nodejs
-, pnpm_9
+, pnpm_10
 , fetchPnpmDeps
 , pnpmConfigHook
 , python3
@@ -33,9 +33,9 @@ python3.pkgs.buildPythonPackage rec {
       rm pnpm-workspace.yaml
     '';
 
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     sourceRoot = "${src.name}/frontend";
-    hash = "sha256-WgKycKbaZv9lovoo0IaCuV41qS4zUqm4vZxsMQBUdNk=";
+    hash = "sha256-X1L8JYG5hgYMmfg0aa8XhkRU6/oFrYTPiXDIyq77puE=";
   };
 
   pyproject = true;
@@ -44,7 +44,7 @@ python3.pkgs.buildPythonPackage rec {
 
   nativeBuildInputs = [
     nodejs
-    pnpm_9
+    pnpm_10
     pnpmConfigHook
   ];
 


### PR DESCRIPTION
pnpm 9 is marked insecure in current nixpkgs due to multiple known CVEs, preventing Decky Loader from evaluating.